### PR TITLE
Use factory to inject subscribers to clients

### DIFF
--- a/dist/DependencyInjection/CompilerPass/SubscriberPass.php
+++ b/dist/DependencyInjection/CompilerPass/SubscriberPass.php
@@ -30,17 +30,12 @@ class SubscriberPass implements CompilerPassInterface
             return;
         }
 
-        $clients = $container->findTaggedServiceIds('csa_guzzle.client');
-
-        if (!count($clients)) {
-            return;
+        // Factory
+        $factory = $container->findDefinition('csa_guzzle.client_factory');
+        $arg = [];
+        foreach ($subscribers as $subscriber => $options) {
+            $arg[] = new Reference($subscriber);
         }
-
-        foreach ($clients as $id => $options) {
-            $client = $container->findDefinition($id);
-            foreach ($subscribers as $subscriber => $options) {
-                $client->addMethodCall('addSubscriber', [new Reference($subscriber)]);
-            }
-        }
+        $factory->replaceArgument(1, $arg);
     }
 }

--- a/dist/Resources/config/factory.xml
+++ b/dist/Resources/config/factory.xml
@@ -13,6 +13,7 @@
 
         <service id="csa_guzzle.client_factory" class="%csa_guzzle.client_factory.class%">
             <argument>%csa_guzzle.client.class%</argument>
+            <argument />
         </service>
 
     </services>


### PR DESCRIPTION
We use the factory to create clients in services at runtime.
Sadly, we have to inject ourselves all subscribers to each client.

With this commit, the factory does the job for us !
