### PR TITLE
Tag pre-existing Guzzle clients

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -53,4 +53,24 @@ UPGRADE FROM 1.2 to 1.3 [from 1.2 to 1.3]
 
 ### Known Backward-Compatibility Breaks
 
-* None yet
+* `ClientFactory` was deprecated in favor of directly tagging Guzzle clients,
+  and will be removed in 2.0.
+
+  Before:
+
+  ```xml
+  <service
+          id="acme.client"
+          class="%acme.client.class%"
+          factory-service="csa_guzzle.client_factory"
+          factory-method="create">
+      <!-- An array of configuration values -->
+  </service>
+  ```
+
+  After:
+
+  ```xml
+  <service id="acme.client" class="%acme.client.class%">
+      <tag name="csa_guzzle.client" />
+  </service>

--- a/src/DependencyInjection/CompilerPass/SubscriberPass.php
+++ b/src/DependencyInjection/CompilerPass/SubscriberPass.php
@@ -13,6 +13,7 @@ namespace Csa\Bundle\GuzzleBundle\DependencyInjection\CompilerPass;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
@@ -22,15 +23,21 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class SubscriberPass implements CompilerPassInterface
 {
+    const FACTORY_SERVICE_ID = 'csa_guzzle.client_factory';
+    const SUBSCRIBER_TAG = 'csa_guzzle.subscriber';
+    const CLIENT_TAG = 'csa_guzzle.client';
+
     public function process(ContainerBuilder $container)
     {
-        $subscribers = $container->findTaggedServiceIds('csa_guzzle.subscriber');
+        $subscribers = $container->findTaggedServiceIds(self::SUBSCRIBER_TAG);
+
+        $this->addSubscribersToClients($container, $subscribers);
 
         if (!count($subscribers)) {
             return;
         }
 
-        $factory = $container->findDefinition('csa_guzzle.client_factory');
+        $factory = $container->findDefinition(self::FACTORY_SERVICE_ID);
 
         foreach ($subscribers as $subscriber => $options) {
             $factory->addMethodCall('registerSubscriber', [
@@ -38,5 +45,117 @@ class SubscriberPass implements CompilerPassInterface
                 new Reference($subscriber),
             ]);
         }
+    }
+
+    /**
+     * Creates configurator service for each client to add registered subscribers
+     * to each client's emitter. Essentially it's converting the following XML
+     *
+     *     <service id="foo" class="GuzzleHttp\Client">
+     *         <tag name="csa_guzzle.client" subscribers="foo, bar" />
+     *     </service>
+     *
+     * to the  following code in the container (rough equivalent)
+     *
+     *     public function getFoo()
+     *     {
+     *         $client = new GuzzleHttp\Client();
+     *         $client->getEmitter()->attach($this->get('foo'));
+     *         $client->getEmitter()->attach($this->get('bar'));
+     *
+     *         return $client;
+     *     }
+     *
+     * @param ContainerBuilder $container
+     */
+    private function addSubscribersToClients(ContainerBuilder $container, array $taggedSubscriberIds)
+    {
+        $subscriberIds = $this->mapSubscriberIdsByAlias($taggedSubscriberIds);
+
+        foreach ($this->findSubscriberAliasesByClientId($container) as $clientId => $aliases) {
+            $client = $container->findDefinition($clientId);
+
+            $configurator = $this->createConfigurator(array_values($aliases
+                ? array_intersect_key($subscriberIds, array_flip($aliases))
+                : $subscriberIds
+            ));
+
+            // Wraps the previous configurator in case the client already had one.
+            $configurator->addArgument($client->getConfigurator());
+
+            $configuratorId = sprintf('csa_guzzle._configurator.%s', $clientId);
+            $container->setDefinition($configuratorId, $configurator);
+
+            $client->setConfigurator([new Reference($configuratorId), 'configure']);
+        }
+    }
+
+    /**
+     * Finds all tagged clients and lists their registered subscribers by client
+     * ids. Empty arrays are returned for clients specifying no subscribers.
+     *
+     * @param ContainerBuilder $container
+     *
+     * @return array An array of subscriber ids with their consuming client as a key
+     */
+    private function findSubscriberAliasesByClientId(ContainerBuilder $container)
+    {
+        $tagsByClientId = $container->findTaggedServiceIds(self::CLIENT_TAG);
+        $aliases = [];
+
+        foreach ($tagsByClientId as $clientId => $tags) {
+            $subscribers = [];
+
+            foreach ($tags as $tag) {
+                if (isset($tag['subscribers'])) {
+                    $subscribers = array_merge(
+                        $subscribers,
+                        array_map('trim', explode(',', $tag['subscribers']))
+                    );
+                }
+            }
+
+            $aliases[$clientId] = $subscribers;
+        }
+
+        return $aliases;
+    }
+
+    /**
+     * @param array $subscriberIds List of service ids pointing to subscribers
+     *
+     * @return Definition
+     */
+    private function createConfigurator(array $subscriberIds)
+    {
+        $subscriberRefs = array_map(function ($subscriberId) {
+            return new Reference($subscriberId);
+        }, $subscriberIds);
+
+        $configurator = new Definition('Csa\Bundle\GuzzleBundle\DependencyInjection\Configurator\ClientConfigurator');
+        $configurator->setPublic(false);
+        $configurator->addArgument($subscriberRefs);
+
+        return $configurator;
+    }
+
+    /**
+     * @param array $serviceIds
+     *
+     * @return array Subscriber service ids as values & their aliases as keys
+     */
+    private function mapSubscriberIdsByAlias(array $subscriberIds)
+    {
+        $mapped = [];
+
+        foreach ($subscriberIds as $subscriberId => $tags) {
+            foreach ($tags as $tag) {
+                if (isset($tag['alias'])) {
+                    $mapped[$tag['alias']] = $subscriberId;
+                }
+            }
+        }
+
+        return $mapped;
     }
 }

--- a/src/DependencyInjection/Configurator/ClientConfigurator.php
+++ b/src/DependencyInjection/Configurator/ClientConfigurator.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the CsaGuzzleBundle package
+ *
+ * (c) Charles Sarrazin <charles@sarraz.in>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code
+ */
+
+namespace Csa\Bundle\GuzzleBundle\DependencyInjection\Configurator;
+
+use GuzzleHttp\ClientInterface;
+
+class ClientConfigurator
+{
+    /**
+     * @var array|\Traversable
+     */
+    private $subscribers;
+
+    /**
+     * @var callable|null
+     */
+    private $parentConfigurator;
+
+    /**
+     * @param array|\Traversable $subscribers
+     * @param callable|null      $parentConfigurator
+     */
+    public function __construct($subscribers = [], $parentConfigurator = null)
+    {
+        $this->subscribers = $subscribers;
+        $this->parentConfigurator = $parentConfigurator;
+    }
+
+    /**
+     * @param ClientInterface $client
+     */
+    public function configure(ClientInterface $client)
+    {
+        if ($this->parentConfigurator) {
+            call_user_func($this->parentConfigurator, $client);
+        }
+
+        foreach ($this->subscribers as $subscriber) {
+            $client->getEmitter()->attach($subscriber);
+        }
+    }
+}

--- a/src/Factory/ClientFactory.php
+++ b/src/Factory/ClientFactory.php
@@ -18,6 +18,8 @@ use GuzzleHttp\Event\SubscriberInterface;
  * Csa Guzzle client compiler pass
  *
  * @author Charles Sarrazin <charles@sarraz.in>
+ *
+ * @deprecated since version 1.3, to be removed in 2.0
  */
 class ClientFactory
 {

--- a/src/Factory/ClientFactory.php
+++ b/src/Factory/ClientFactory.php
@@ -23,7 +23,6 @@ class ClientFactory
 {
     private $class;
     private $subscribers;
-    private $clientOptions;
 
     /**
      * @param string $class The client's class
@@ -50,43 +49,8 @@ class ClientFactory
         return $client;
     }
 
-    public function createNamed($alias)
-    {
-        if (!isset($this->clientOptions[$alias])) {
-            throw new \InvalidArgumentException(sprintf('Could not find configuration for client "%s"', $alias));
-        }
-
-        $clientOptions = $this->clientOptions[$alias];
-
-        $client = new $this->class($clientOptions['options']);
-
-        if (!$client instanceof HasEmitterInterface) {
-            return;
-        }
-
-        $clientSubscribers = $clientOptions['subscribers'];
-
-        $subscribers = array_filter(array_keys($this->subscribers), function ($name) use ($clientSubscribers) {
-            return !isset($clientSubscribers[$name]) || $clientSubscribers[$name];
-        });
-
-        foreach ($subscribers as $subscriber) {
-            $client->getEmitter()->attach($this->subscribers[$subscriber]);
-        }
-
-        return $client;
-    }
-
     public function registerSubscriber($name, SubscriberInterface $subscriber)
     {
         $this->subscribers[$name] = $subscriber;
-    }
-
-    public function registerClientConfiguration($alias, array $options = [], array $subscribers = [])
-    {
-        $this->clientOptions[$alias] = [
-            'options' => $options,
-            'subscribers' => $subscribers,
-        ];
     }
 }

--- a/src/Resources/config/factory.xml
+++ b/src/Resources/config/factory.xml
@@ -11,8 +11,6 @@
             <argument type="collection" />
         </service>
 
-        <service id="csa_guzzle.client.abstract" abstract="true" />
-
     </services>
 
 </container>

--- a/src/Resources/doc/clients.md
+++ b/src/Resources/doc/clients.md
@@ -4,7 +4,7 @@ Creating a service for your client
 There are two ways for creating a service for your client:
 
 * Using the semantic configuration (Beginners)
-* Creating your own service, using the provided factory (Advanced users)
+* Registering your own service (Advanced users)
 
 Creating a client using semantic configuration
 ----------------------------------------------
@@ -39,17 +39,13 @@ class MyController extends Controller
 }
 ```
 
-Creating a client using the provided factory service
-----------------------------------------------------
+Registering your own service
+----------------------------
 
-Simply create a service as follows:
+To have a client supported by the bundle, simply tag it as such:
 
 ```xml
-<service
-        id="acme.client"
-        class="%acme.client.class%"
-        factory-service="csa_guzzle.client_factory"
-        factory-method="create">
-    <!-- An array of configuration values -->
+<service id="acme.client" class="%acme.client.class%">
+    <tag name="csa_guzzle.client" />
 </service>
 ```

--- a/src/Resources/doc/event_subscribers.md
+++ b/src/Resources/doc/event_subscribers.md
@@ -31,3 +31,14 @@ csa_guzzle:
                 logger: false
                 my_subscriber: false # Note the use of the alias defined earlier in the service definition.
 ```
+
+When registering your own clients with the bundle, you can explicitly list all
+enabled subscribers. The `subscribers` attribute takes a comma-delimited list of
+subscriber names. In that case any other subscriber will be disabled for that
+client:
+
+```xml
+<service id="acme.client" class="%acme.client.class%">
+    <tag name="csa_guzzle.client" subscribers="my_subscriber,another_subscriber" />
+</service>
+```

--- a/src/Tests/DependencyInjection/CompilerPass/SubscriberPassTest.php
+++ b/src/Tests/DependencyInjection/CompilerPass/SubscriberPassTest.php
@@ -1,0 +1,134 @@
+<?php
+
+/*
+ * This file is part of the CsaGuzzleBundle package
+ *
+ * (c) Charles Sarrazin <charles@sarraz.in>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code
+ */
+
+namespace Csa\Bundle\GuzzleBundle\Tests\DependencyInjection\CompilerPass;
+
+use Csa\Bundle\GuzzleBundle\DependencyInjection\CompilerPass\SubscriberPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+class SubscriberPassTest extends \PHPUnit_Framework_TestCase
+{
+    public function testSubscriberRegisteredToFactory()
+    {
+        $container = $this->createContainer();
+        $container->setDefinition('sub', $this->createSubscriber('my_sub'));
+
+        $pass = new SubscriberPass();
+        $pass->process($container);
+
+        $calls = $container
+            ->findDefinition(SubscriberPass::FACTORY_SERVICE_ID)
+            ->getMethodCalls()
+        ;
+
+        $this->assertCount(1, $calls);
+
+        $methodName = $calls[0][0];
+        $methodArgs = $calls[0][1];
+
+        $this->assertEquals('registerSubscriber', $methodName);
+        $this->assertEquals('my_sub', $methodArgs[0]);
+        $this->assertEquals('sub', (string) $methodArgs[1]);
+    }
+
+    public function testAllSubscribersAddedToTaggedClientsByDefault()
+    {
+        $container = $this->createContainer();
+        $container->setDefinition('client', $client = $this->createClient());
+        $container->setDefinition('sub', $this->createSubscriber('my_sub'));
+
+        $pass = new SubscriberPass();
+        $pass->process($container);
+
+        $this->assertNotNull($callback = $client->getConfigurator());
+
+        $this->assertEquals('configure', $callback[1]);
+        $configurator = $container->findDefinition($callback[0]);
+
+        $this->assertEquals(array(new Reference('sub')), $configurator->getArgument(0));
+    }
+
+    public function testSpecificSubscribersAddedToClient()
+    {
+        $client = $this->createClient($expected = ['foo', 'bar']);
+
+        $container = $this->createContainer();
+        $container->setDefinition('client', $client);
+
+        foreach (['foo', 'bar', 'qux'] as $alias) {
+            $container ->setDefinition($alias, $this->createSubscriber($alias));
+        }
+
+        $pass = new SubscriberPass();
+        $pass->process($container);
+
+        $references = $container
+            ->findDefinition($client->getConfigurator()[0])
+            ->getArgument(0)
+        ;
+
+        $subscribers = array_map(function ($reference) {
+            return (string) $reference;
+        }, $references);
+
+        $this->assertEquals(['foo', 'bar'], $subscribers, 'Only the specified subscribers must be added.');
+    }
+
+    public function testPreviousConfiguratorWrapped()
+    {
+        $client = $this->createClient();
+        $client->setConfigurator($parent = [new Reference('foo'), 'configure']);
+
+        $container = $this->createContainer();
+        $container->setDefinition('client', $client);
+        $container->setDefinition('sub', $this->createSubscriber('my_sub'));
+
+        $pass = new SubscriberPass();
+        $pass->process($container);
+
+        $callback = $client->getConfigurator();
+        $this->assertNotSame($parent, $callback, 'Subscriber pass should have replaced the configurator.');
+
+        $configurator = $container->findDefinition($callback[0]);
+        $this->assertCount(2, $configurator->getArguments(), 'The parent configurator should have been passed as the 2nd argument.');
+
+        $this->assertSame($parent, $configurator->getArgument(1));
+    }
+
+    private function createSubscriber($alias)
+    {
+        $subscriber = new Definition();
+        $subscriber->addTag(SubscriberPass::SUBSCRIBER_TAG, ['alias' => $alias]);
+
+        return $subscriber;
+    }
+
+    private function createClient(array $subscribers = null)
+    {
+        $client = new Definition();
+        $client->addTag(
+            SubscriberPass::CLIENT_TAG,
+            $subscribers ? ['subscribers' => implode(', ', $subscribers)] : []
+        );
+
+        return $client;
+    }
+
+    private function createContainer()
+    {
+        $container = new ContainerBuilder();
+        $container->setDefinition(SubscriberPass::FACTORY_SERVICE_ID, new Definition());
+
+        return $container;
+    }
+}

--- a/src/Tests/DependencyInjection/Configurator/ClientConfiguratorTest.php
+++ b/src/Tests/DependencyInjection/Configurator/ClientConfiguratorTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the CsaGuzzleBundle package
+ *
+ * (c) Charles Sarrazin <charles@sarraz.in>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code
+ */
+
+namespace Csa\Bundle\GuzzleBundle\Tests\DependencyInjection\Configurator;
+
+use GuzzleHttp\ClientInterface;
+use Csa\Bundle\GuzzleBundle\DependencyInjection\Configurator\ClientConfigurator;
+
+class ClientConfiguratorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testSubscribersAttachedToEmitter()
+    {
+        $subscriber = $this->getMockSubscriber();
+
+        $emitter = $this->getMockEmitter();
+        $emitter
+            ->expects($this->once())
+            ->method('attach')
+            ->with($this->identicalTo($subscriber))
+        ;
+
+        $client = $this->getMockClient();
+        $client->method('getEmitter')->willReturn($emitter);
+
+        $configurator = new ClientConfigurator([$subscriber]);
+        $configurator->configure($client);
+    }
+
+    public function testParentConfiguratorCalled()
+    {
+        $parentCalled = false;
+        $parent = function (ClientInterface $client) use (&$parentCalled) {
+            $parentCalled = true;
+        };
+
+        $configurator = new ClientConfigurator([], $parent);
+        $configurator->configure($this->getMockClient());
+
+        $this->assertTrue($parentCalled, 'Parent configuration must be called');
+    }
+
+    private function getMockClient()
+    {
+        return $this->getMock('GuzzleHttp\ClientInterface');
+    }
+
+    private function getMockEmitter()
+    {
+        return $this->getMock('GuzzleHttp\Event\EmitterInterface');
+    }
+
+    private function getMockSubscriber()
+    {
+        return $this->getMock('GuzzleHttp\Event\SubscriberInterface');
+    }
+}

--- a/src/Tests/DependencyInjection/CsaGuzzleExtensionTest.php
+++ b/src/Tests/DependencyInjection/CsaGuzzleExtensionTest.php
@@ -22,7 +22,7 @@ class CsaGuzzleExtensionTest extends \PHPUnit_Framework_TestCase
     {
         $yaml = <<<YAML
 profiler:
-    enabled: true
+    enabled: false
 clients:
     foo:
         config: { base_url: example.com }
@@ -44,6 +44,31 @@ YAML;
             ['base_url' => 'example.com'],
             $client->getArgument(0),
             'Config must be passed to client constructor.'
+        );
+    }
+
+    public function testSubscribersAddedToClient()
+    {
+        $yaml = <<<YAML
+logger: true
+profiler: true
+clients:
+    foo:
+        subscribers:
+            stopwatch: false
+            debug: true
+YAML;
+
+        $container = $this->createContainer($yaml);
+
+        $this->assertTrue($container->hasDefinition('csa_guzzle.client.foo'), 'Client must be created.');
+
+        $client = $container->getDefinition('csa_guzzle.client.foo');
+
+        $this->assertEquals(
+            [SubscriberPass::CLIENT_TAG => [['subscribers' => 'debug,logger']]],
+            $client->getTags(),
+            'Only explicitly disabled subscribers shouldn\'t be added.'
         );
     }
 

--- a/src/Tests/DependencyInjection/CsaGuzzleExtensionTest.php
+++ b/src/Tests/DependencyInjection/CsaGuzzleExtensionTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the CsaGuzzleBundle package
+ *
+ * (c) Charles Sarrazin <charles@sarraz.in>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code
+ */
+
+namespace Csa\Bundle\GuzzleBundle\DependencyInjection;
+
+use Csa\Bundle\GuzzleBundle\DependencyInjection\CompilerPass\SubscriberPass;
+use Csa\Bundle\GuzzleBundle\DependencyInjection\CsaGuzzleExtension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Yaml\Parser;
+
+class CsaGuzzleExtensionTest extends \PHPUnit_Framework_TestCase
+{
+    public function testClientCreated()
+    {
+        $yaml = <<<YAML
+profiler:
+    enabled: true
+clients:
+    foo:
+        config: { base_url: example.com }
+YAML;
+
+        $container = $this->createContainer($yaml);
+
+        $this->assertTrue($container->hasDefinition('csa_guzzle.client.foo'), 'Client must be created.');
+
+        $client = $container->getDefinition('csa_guzzle.client.foo');
+
+        $this->assertEquals(
+            [SubscriberPass::CLIENT_TAG => [['subscribers' => '']]],
+            $client->getTags(),
+            'Clients must be tagged.'
+        );
+
+        $this->assertEquals(
+            ['base_url' => 'example.com'],
+            $client->getArgument(0),
+            'Config must be passed to client constructor.'
+        );
+    }
+
+    private function createContainer($yaml)
+    {
+        $parser = new Parser();
+        $container = new ContainerBuilder();
+
+        $loader = new CsaGuzzleExtension();
+        $loader->load([$parser->parse($yaml)], $container);
+
+        return $container;
+    }
+}


### PR DESCRIPTION
Alright, here's a rough implementation for tagging existing Guzzle clients. Here's how it works:

1. Tag a service with `csa_guzzle.client` (with optional `subscribers="foo, bar, baz"` attribute);
2. Let the DI container do its magic;
3. Success!

For example, one of the subscriber pass tests gets compiled down to [the following](https://gist.github.com/kgilden/dd62730a4b4a65c9bf3b). I'm a bit annoyed by the fact that it's not inlining confiugration creation. Need to investigate this a bit more.

I assumed this was going into v1.3, but feel free to change any of the deprecation stuff as you see fit.