### PR TITLE
Deprecate client factory

### DIFF
--- a/src/DependencyInjection/CompilerPass/SubscriberPass.php
+++ b/src/DependencyInjection/CompilerPass/SubscriberPass.php
@@ -140,7 +140,7 @@ class SubscriberPass implements CompilerPassInterface
     }
 
     /**
-     * @param array $serviceIds
+     * @param array $subscriberIds
      *
      * @return array Subscriber service ids as values & their aliases as keys
      */

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -35,6 +35,14 @@ class Configuration implements ConfigurationInterface
         $rootNode = $treeBuilder->root('csa_guzzle');
 
         $rootNode
+            ->beforeNormalization()
+                ->ifTrue(function ($v) {
+                    return isset($v['factory_class']);
+                })
+                ->then(function ($v) {
+                    trigger_error('The ClientFactory class is deprecated since version 1.3 and will be removed in 2.0. Use the \'csa_guzzle.client\' tag instead', E_USER_DEPRECATED);
+                })
+            ->end()
             ->fixXmlConfig('client')
             ->children()
                 ->arrayNode('profiler')

--- a/src/DependencyInjection/CsaGuzzleExtension.php
+++ b/src/DependencyInjection/CsaGuzzleExtension.php
@@ -71,7 +71,7 @@ class CsaGuzzleExtension extends Extension
         $definition = $container->getDefinition('csa_guzzle.client_factory');
         $definition->replaceArgument(0, $config['factory_class']);
 
-        $this->processClientsConfiguration($config, $container, $definition, $descriptionFactory);
+        $this->processClientsConfiguration($config, $container, $descriptionFactory);
     }
 
     private function processCacheConfiguration(array $config, ContainerBuilder $container)
@@ -94,7 +94,7 @@ class CsaGuzzleExtension extends Extension
         $container->setAlias('csa_guzzle.default_cache_adapter', $adapterId);
     }
 
-    private function processClientsConfiguration(array $config, ContainerBuilder $container, Definition $clientFactory, Definition $descriptionFactory)
+    private function processClientsConfiguration(array $config, ContainerBuilder $container, Definition $descriptionFactory)
     {
         foreach ($config['clients'] as $name => $options) {
             $client = new Definition($config['factory_class']);

--- a/src/Factory/ClientFactory.php
+++ b/src/Factory/ClientFactory.php
@@ -34,7 +34,6 @@ class ClientFactory
     {
         $this->class = $class;
         $this->subscribers = [];
-        $this->clientOptions = [];
     }
 
     /**
@@ -52,7 +51,7 @@ class ClientFactory
 
         if ($client instanceof HasEmitterInterface) {
             foreach ($this->subscribers as $name => $subscriber) {
-                if (!$subscribers || (isset($subscribers[$name]) && $subscribers[$name])) {
+                if (empty($subscribers) || (isset($subscribers[$name]) && $subscribers[$name])) {
                     $client->getEmitter()->attach($subscriber);
                 }
             }

--- a/src/Factory/ClientFactory.php
+++ b/src/Factory/ClientFactory.php
@@ -47,7 +47,7 @@ class ClientFactory
      */
     public function create(array $options = [], array $subscribers = [])
     {
-        trigger_error('The ClientFactory class is deprecated since version 1.3 and will be removed in 2.0. Use the \`csa_guzzle.client\` tag instead', E_USER_DEPRECATED);
+        trigger_error('The ClientFactory class is deprecated since version 1.3 and will be removed in 2.0. Use the \'csa_guzzle.client\' tag instead', E_USER_DEPRECATED);
         $client = new $this->class($options);
 
         if ($client instanceof HasEmitterInterface) {
@@ -63,7 +63,7 @@ class ClientFactory
 
     public function registerSubscriber($name, SubscriberInterface $subscriber)
     {
-        trigger_error('The ClientFactory class is deprecated since version 1.3 and will be removed in 2.0. Use the \`csa_guzzle.client\` tag instead', E_USER_DEPRECATED);
+        trigger_error('The ClientFactory class is deprecated since version 1.3 and will be removed in 2.0. Use the \'csa_guzzle.client\' tag instead', E_USER_DEPRECATED);
         $this->subscribers[$name] = $subscriber;
     }
 }

--- a/src/Factory/DescriptionFactory.php
+++ b/src/Factory/DescriptionFactory.php
@@ -48,7 +48,7 @@ class DescriptionFactory
      */
     public function loadDescriptions()
     {
-        if ($this->descriptions) {
+        if (!empty($this->descriptions)) {
             return;
         }
 

--- a/src/GuzzleHttp/Subscriber/CacheSubscriber.php
+++ b/src/GuzzleHttp/Subscriber/CacheSubscriber.php
@@ -57,6 +57,6 @@ class CacheSubscriber implements SubscriberInterface
 
     public function onComplete(CompleteEvent $event)
     {
-        $this->storage->save($event->getRequest(), $event->getResponse(), $event->getTransferInfo());
+        $this->storage->save($event->getRequest(), $event->getResponse());
     }
 }

--- a/src/Tests/DependencyInjection/CsaGuzzleExtensionTest.php
+++ b/src/Tests/DependencyInjection/CsaGuzzleExtensionTest.php
@@ -149,6 +149,17 @@ YAML;
         $this->assertSame('my.service.id', (string)$container->getDefinition((string) $alias)->getArgument(0));
     }
 
+    public function testLegacyFactoryConfiguration()
+    {
+        $yaml = <<<YAML
+factory_class: GuzzleHttp\Client
+YAML;
+
+        $container = $this->createContainer($yaml);
+        $factory = $container->getDefinition('csa_guzzle.client_factory');
+        $this->assertSame('GuzzleHttp\Client', $factory->getArgument(0));
+    }
+
     /**
      * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
      * @expectedExceptionMessage Invalid configuration for path "csa_guzzle.cache.adapter.type": Invalid cache adapter

--- a/src/Tests/GuzzleHttp/Subscriber/CacheSubscriberTest.php
+++ b/src/Tests/GuzzleHttp/Subscriber/CacheSubscriberTest.php
@@ -36,8 +36,7 @@ class DoctrineAdapterTest extends \PHPUnit_Framework_TestCase
             ->method('save')
             ->with(
                 $this->isInstanceOf('GuzzleHttp\Message\RequestInterface'),
-                $this->equalTo($response),
-                $this->isType('array')
+                $this->equalTo($response)
             )
         ;
         $adapter


### PR DESCRIPTION
As mentioned in earlier issues, the Client factory will be deprecated for version 2.0 of the bundle, being replaced by the tag + configurator syntax.