### PR TITLE
Enable client class override

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -88,6 +88,7 @@ class Configuration implements ConfigurationInterface
             ->useAttributeAsKey('name')
             ->prototype('array')
                 ->children()
+                    ->scalarNode('class')->defaultValue('GuzzleHttp\Client')->end()
                     ->variableNode('config')->end()
                     ->arrayNode('subscribers')
                         ->useAttributeAsKey('subscriber_name')

--- a/src/DependencyInjection/CsaGuzzleExtension.php
+++ b/src/DependencyInjection/CsaGuzzleExtension.php
@@ -97,7 +97,7 @@ class CsaGuzzleExtension extends Extension
     private function processClientsConfiguration(array $config, ContainerBuilder $container, Definition $descriptionFactory)
     {
         foreach ($config['clients'] as $name => $options) {
-            $client = new Definition($config['factory_class']);
+            $client = new Definition($options['class']);
             $client->addArgument(isset($options['config']) ? $options['config'] : null);
             $client->addTag(
                 SubscriberPass::CLIENT_TAG,

--- a/src/Resources/doc/clients.md
+++ b/src/Resources/doc/clients.md
@@ -39,6 +39,20 @@ class MyController extends Controller
 }
 ```
 
+If you override your client's class, you can also set the class for your client:
+
+```yml
+csa_guzzle:
+    clients:
+        my_client:
+            class: AppBundle\Client
+            # ...
+```
+
+Of course, you need to make sure that your client class has no constructor arguments.
+
+If you need to pass constructor arguments to your class, then you should use the tag syntax (see below).
+
 Registering your own service
 ----------------------------
 

--- a/src/Tests/DependencyInjection/CsaGuzzleExtensionTest.php
+++ b/src/Tests/DependencyInjection/CsaGuzzleExtensionTest.php
@@ -49,6 +49,21 @@ YAML;
         );
     }
 
+    public function testClientClassOverride()
+    {
+        $yaml = <<<YAML
+clients:
+    foo:
+        class: AppBundle\Client
+YAML;
+
+        $container = $this->createContainer($yaml);
+
+        $client = $container->getDefinition('csa_guzzle.client.foo');
+
+        $this->assertEquals('AppBundle\Client', $client->getClass());
+    }
+
     public function testClientWithDescription()
     {
         $yaml = <<<YAML


### PR DESCRIPTION
Enables class configuration for a specific client. This enables the use of specific clients by the bundle.

E.g.

```yml
csa_guzzle:
    clients:
        github_api:
            config:
                class: AppBundle\Client
                # ...
```

Fixes #36 