### PR TITLE
Fixed cache key

### DIFF
--- a/src/GuzzleHttp/Cache/DoctrineAdapter.php
+++ b/src/GuzzleHttp/Cache/DoctrineAdapter.php
@@ -46,7 +46,7 @@ class DoctrineAdapter implements StorageAdapterInterface
             'method'  => $request->getMethod(),
             'uri'     => $request->getUrl(),
             'headers' => $request->getHeaders(),
-            'body'    => $request->getBody(),
+            'body'    => (string) $request->getBody(),
         ]));
     }
 }


### PR DESCRIPTION
The request's body is not correctly serialized since it's a stream, so the key can be the same for requests having just a different body.
Type casting to string resolves the problem.