### PR TITLE
[WIP] Fix cache key

### DIFF
--- a/src/GuzzleHttp/Cache/DoctrineAdapter.php
+++ b/src/GuzzleHttp/Cache/DoctrineAdapter.php
@@ -46,7 +46,7 @@ class DoctrineAdapter implements StorageAdapterInterface
             'method'  => $request->getMethod(),
             'uri'     => $request->getUrl(),
             'headers' => $request->getHeaders(),
-            'body'    => $request->getBody(),
+            'body'    => (string)$request->getBody(),
         ]));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT

**Issue :** 
When having two same requests with different bodys, we're having the same cache key. We're expecting  having two different cache keys, since the Body of the request is used in the hash.

**Fix :**
Use Body Content for the cache key in `DoctrineAdapter` instead of the SteamObject.

- [ ] Write tests