### PR TITLE
Fix CsaGuzzleExtension to allow symfony services

### DIFF
--- a/src/DependencyInjection/CsaGuzzleExtension.php
+++ b/src/DependencyInjection/CsaGuzzleExtension.php
@@ -98,7 +98,8 @@ class CsaGuzzleExtension extends Extension
     {
         foreach ($config['clients'] as $name => $options) {
             $client = new Definition($options['class']);
-            $client->addArgument(isset($options['config']) ? $options['config'] : null);
+
+            $client->addArgument($this->buildGuzzleConfig($options));
             $client->addTag(
                 SubscriberPass::CLIENT_TAG,
                 ['subscribers' => implode(',', $this->findSubscriberIds($options['subscribers'], $container))]
@@ -131,5 +132,21 @@ class CsaGuzzleExtension extends Extension
         return array_filter($allNames, function ($name) use ($explicitlyConfiguredIds) {
             return !isset($explicitlyConfiguredIds[$name]) || $explicitlyConfiguredIds[$name];
         });
+    }
+
+    private function buildGuzzleConfig($options)
+    {
+        if (!isset($options['config'])) {
+            return null;
+        }
+
+        $config = $options['config'];
+        foreach (array('message_factory', 'fsm', 'adapter', 'handler') as $service) {
+            if (isset($config[$service])) {
+                $config[$service] = new Reference($config[$service]);
+            }
+        }
+
+        return $config;
     }
 }

--- a/src/Tests/DependencyInjection/CsaGuzzleExtensionTest.php
+++ b/src/Tests/DependencyInjection/CsaGuzzleExtensionTest.php
@@ -68,9 +68,8 @@ YAML;
      * @dataProvider clientConfigInstance
      * @covers CsaGuzzleExtension::buildGuzzleConfig
      */
-    public function testClientConfigInstanceOverride($instanceKey)
+    public function testClientConfigInstanceOverride($instanceKey, $serviceId)
     {
-        $serviceId = 'my.message.factory.id';
         $yaml = <<<YAML
 clients:
     foo:
@@ -88,6 +87,21 @@ YAML;
             $serviceId,
             (string)$config[$instanceKey]
         );
+    }
+
+    /**
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Config for "csa_guzzle.client.foo" should be an array, but got string
+     */
+    public function testInvalidClientConfig()
+    {
+        $yaml = <<<YAML
+clients:
+    foo:
+        config: invalid
+YAML;
+
+        $this->createContainer($yaml);
     }
 
     public function testClientWithDescription()
@@ -231,10 +245,10 @@ YAML;
     public function clientConfigInstance()
     {
         return array(
-            array('message_factory'),
-            array('fsm'),
-            array('adapter'),
-            array('handler'),
+            array('message_factory', 'my.message.factory.id'),
+            array('fsm', 'my.fsm.id'),
+            array('adapter', 'my.adapter.id'),
+            array('handler', 'my.handler.id'),
         );
     }
 }

--- a/src/Tests/DependencyInjection/CsaGuzzleExtensionTest.php
+++ b/src/Tests/DependencyInjection/CsaGuzzleExtensionTest.php
@@ -64,6 +64,32 @@ YAML;
         $this->assertEquals('AppBundle\Client', $client->getClass());
     }
 
+    /**
+     * @dataProvider clientConfigInstance
+     * @covers CsaGuzzleExtension::buildGuzzleConfig
+     */
+    public function testClientConfigInstanceOverride($instanceKey)
+    {
+        $serviceId = 'my.message.factory.id';
+        $yaml = <<<YAML
+clients:
+    foo:
+        config:
+            {$instanceKey}: {$serviceId}
+YAML;
+
+        $container = $this->createContainer($yaml);
+        $config = $container->getDefinition('csa_guzzle.client.foo')->getArgument(0);
+        $this->assertInstanceOf(
+            'Symfony\Component\DependencyInjection\Reference',
+            $config[$instanceKey]
+        );
+        $this->assertSame(
+            $serviceId,
+            (string)$config[$instanceKey]
+        );
+    }
+
     public function testClientWithDescription()
     {
         $yaml = <<<YAML
@@ -200,5 +226,15 @@ YAML;
         $loader->load([$parser->parse($yaml)], $container);
 
         return $container;
+    }
+
+    public function clientConfigInstance()
+    {
+        return array(
+            array('message_factory'),
+            array('fsm'),
+            array('adapter'),
+            array('handler'),
+        );
     }
 }

--- a/src/Tests/DependencyInjection/CsaGuzzleExtensionTest.php
+++ b/src/Tests/DependencyInjection/CsaGuzzleExtensionTest.php
@@ -91,14 +91,16 @@ YAML;
 
     /**
      * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Config for "csa_guzzle.client.foo" should be an array, but got string
+     * @expectedExceptionMessage Config for "csa_guzzle.client.bar" should be an array, but got string
      */
     public function testInvalidClientConfig()
     {
         $yaml = <<<YAML
 clients:
     foo:
-        config: invalid
+        config: ~       # legacy mode
+    bar:
+        config: invalid # exception
 YAML;
 
         $this->createContainer($yaml);


### PR DESCRIPTION
Hello,
This is a fix in CsaGuzzleExtension to allow symfony services where class instances are used directly from config array.

In GuzzleHttp/Client::__construct(), four keys are expected to be instances of a class.
Namely *message_factory*, *fsm*, *handler* and *adapter*.

My personal use case, required me to extend the _message_factory_ class for some special routines.
This appears to be an oversight in both 1.3 and 2.0 (where only the handler key remains)

Also added some tests for this scenario.

Best Regards,
Khez