### PR TITLE
Disallow build failures for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,7 @@ matrix:
     - php: 5.5
     - php: 5.6
     - php: hhvm
-    - php: nightly
-  allow_failures:
-    - php: nightly
-    - php: hhvm
+    - php: 7.0
   fast_finish: true
 
 install:


### PR DESCRIPTION
Removed hhvm and php 7 from allowed_failures, as tests pass on all platforms