### PR TITLE
Fix profiler call headers

### DIFF
--- a/src/Resources/views/Calls/call.html.twig
+++ b/src/Resources/views/Calls/call.html.twig
@@ -24,12 +24,12 @@
         <div class="tab-content">
             <div class="tab-pane active" id="request-{{ loop.index }}">
                 {{ macros.render_infos(call.info) }}
-                {{ macros.render_headers(call.request.headers, call.uri) }}
+                {{ macros.render_headers(call.request.headers, call.url) }}
                 {{ macros.render_body(call.request.body) }}
             </div>
             {% if call.response is defined %}
             <div class="tab-pane" id="response-{{ loop.index }}">
-                {{ macros.render_headers(call.response.headers, call.uri) }}
+                {{ macros.render_headers(call.response.headers, call.url) }}
                 {{ macros.render_body(call.response.body) }}
             </div>
             {% endif %}


### PR DESCRIPTION
`call.uri` used in `Calls/call.html.twig` view doesn't exist.