### PR TITLE
Made templates more homogeneous between branches 1.x and 2.x

### DIFF
--- a/src/DataCollector/GuzzleCollector.php
+++ b/src/DataCollector/GuzzleCollector.php
@@ -62,7 +62,7 @@ class GuzzleCollector extends DataCollector
                     'body'    => $this->cropContent($request->getBody()),
                 ],
                 'info' => $info,
-                'url'     => $request->getUrl(),
+                'uri'     => $request->getUrl(),
             ];
 
             if ($response) {

--- a/src/Resources/views/Calls/call.html.twig
+++ b/src/Resources/views/Calls/call.html.twig
@@ -4,9 +4,9 @@
     <header data-toggle="collapse" data-target="#collapse-call-{{ loop.index }}">
         <span class="method">{{ call.request.method }}</span>
         {% if call.request.method == 'GET' %}
-            <h3><a href="{{ call.url }}" target="_blank" class="path">{{ call.url }}</a></h3>
+            <h3><a href="{{ call.uri }}" target="_blank" class="path">{{ call.uri }}</a></h3>
         {% else %}
-            <span class="path">{{ call.url }}</span>
+            <span class="path">{{ call.uri }}</span>
         {% endif %}
         {% set statusCode = call.httpCode %}
         <span class="status-code badge {{ statusCode|csa_guzzle_status_code_class }}">
@@ -24,12 +24,12 @@
         <div class="tab-content">
             <div class="tab-pane active" id="request-{{ loop.index }}">
                 {{ macros.render_infos(call.info) }}
-                {{ macros.render_headers(call.request.headers, call.url) }}
+                {{ macros.render_headers(call.request.headers, call.uri) }}
                 {{ macros.render_body(call.request.body) }}
             </div>
             {% if call.response is defined %}
             <div class="tab-pane" id="response-{{ loop.index }}">
-                {{ macros.render_headers(call.response.headers, call.url) }}
+                {{ macros.render_headers(call.response.headers, call.uri) }}
                 {{ macros.render_body(call.response.body) }}
             </div>
             {% endif %}


### PR DESCRIPTION
This PR makes templates a lot more alike between `v1.x` and `v2.x` of the bundle. This will prevent future regressions like the latest merge, where we can find both `url` and `uri` in the `call.html.twig` template.