### PR TITLE
Add support for setting a middleware's priority

### DIFF
--- a/src/Resources/config/middleware.xml
+++ b/src/Resources/config/middleware.xml
@@ -19,7 +19,7 @@
         <service id="csa_guzzle.middleware.history" class="Closure">
             <factory class="Csa\Bundle\GuzzleBundle\GuzzleHttp\Middleware" method="history" />
             <argument type="expression">service('csa_guzzle.data_collector.guzzle').getHistory()</argument>
-            <tag name="csa_guzzle.middleware" alias="history" />
+            <tag name="csa_guzzle.middleware" alias="history" priority="-1000" />
         </service>
 
         <service id="csa_guzzle.middleware.logger" class="Closure">


### PR DESCRIPTION
Middleware can now be prioritized. The default priority is `0`, and it can be set by using the `priority` property in the `csa_guzzle.middleware` DI tag:

e.g:

```xml
        <service id="csa_guzzle.middleware.history" class="Closure">
            <factory class="Csa\Bundle\GuzzleBundle\GuzzleHttp\Middleware" method="history" />
            <argument type="expression">service('csa_guzzle.data_collector.guzzle').getHistory()</argument>
            <tag name="csa_guzzle.middleware" alias="history" priority="-1000" />
        </service>
```

Solves #90 