### PR TITLE
Fix MiddlewarePass when no middleware registered

### DIFF
--- a/src/DependencyInjection/CompilerPass/MiddlewarePass.php
+++ b/src/DependencyInjection/CompilerPass/MiddlewarePass.php
@@ -54,16 +54,16 @@ class MiddlewarePass implements CompilerPassInterface
                 throw new \LogicException('The \'alias\' attribute is mandatory for the \'csa_guzzle.middleware\' tag');
             }
 
-            if (!isset($tags[0]['priority'])) {
-                $services[$id][0]['priority'] = 0;
-            }
-
-            $priority = (string) $services[$id][0]['priority'];
+            $priority = isset($tags[0]['priority']) ? $tags[0]['priority'] : 0;
 
             $middleware[$priority][] = [
                 'alias' => $tags[0]['alias'],
                 'id' => $id,
             ];
+        }
+
+        if (empty($middleware)) {
+            return [];
         }
 
         krsort($middleware);


### PR DESCRIPTION
We had no middleware enabled in production env (no log, no profiler) which results in these errors:

> Warning: array_merge() expects at least 1 parameter, 0 given in /vagrant/vendor/csa/guzzle-bundle/src/DependencyInjection/CompilerPass/MiddlewarePass.php on line 71

> Catchable fatal error: Argument 2 passed to Csa\Bundle\GuzzleBundle\DependencyInjection\CompilerPass\MiddlewarePass::registerMiddleware() must be of the type array, null given, called in /vagrant/vendor/csa/guzzle-bundle/src/DependencyInjection/CompilerPass/MiddlewarePass.php on line 33 and defined in /vagrant/vendor/csa/guzzle-bundle/src/DependencyInjection/CompilerPass/MiddlewarePass.php on line 80