### PR TITLE
Do not set handler when no middleware registered

### DIFF
--- a/src/DependencyInjection/CompilerPass/MiddlewarePass.php
+++ b/src/DependencyInjection/CompilerPass/MiddlewarePass.php
@@ -79,6 +79,10 @@ class MiddlewarePass implements CompilerPassInterface
      */
     private function registerMiddleware(ContainerBuilder $container, array $middlewareBag)
     {
+        if (empty($middlewareBag)) {
+            return;
+        }
+
         $clients = $container->findTaggedServiceIds(self::CLIENT_TAG);
 
         foreach ($clients as $clientId => $tags) {
@@ -93,6 +97,10 @@ class MiddlewarePass implements CompilerPassInterface
                 $clientMiddleware = array_filter($clientMiddleware, function ($value) use ($whitelist) {
                     return in_array($value['alias'], $whitelist, true);
                 });
+            }
+
+            if (empty($clientMiddleware)) {
+                continue;
             }
 
             $clientDefinition = $container->findDefinition($clientId);

--- a/src/Tests/DependencyInjection/CompilerPass/MiddlewarePassTest.php
+++ b/src/Tests/DependencyInjection/CompilerPass/MiddlewarePassTest.php
@@ -85,8 +85,7 @@ class MiddlewarePassTest extends \PHPUnit_Framework_TestCase
         $pass = new MiddlewarePass();
         $pass->process($container);
 
-        $handlerDefinition = $client->getArgument(0)['handler'];
-        $this->assertCount(0, $handlerDefinition->getMethodCalls());
+        $this->assertCount(0, $client->getArguments());
     }
 
     public function testHandlerIsKeptByCompilerPass()


### PR DESCRIPTION
If no middleware is available we can skip this logic. This is relevant when for example no `handler` option is defined. In theory I could have a GuzzleClient subclass that creates a custom handler instead of the default one (`HandlerStack::create`)