### PR TITLE
[RFR] Fixing guzzle item displaying in WebProfiler toolbar

### DIFF
--- a/src/Resources/views/Collector/guzzle.html.twig
+++ b/src/Resources/views/Collector/guzzle.html.twig
@@ -73,11 +73,11 @@
 
         </span>
         <strong>{{ collector.name|capitalize|default('HTTP calls') }}</strong>
-        <span class="count">
-            {% if collector.calls is not empty %}
+        {% if collector.calls is not empty %}
+            <span class="count">
                 <span>{{ collector.calls|length }}</span>
-            {% endif %}
-        </span>
+            </span>
+        {% endif %}    
     </span>
 {% endblock %}
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT

When there is no guzzle request. there is a little glitch in the Guzzle Item in the new  WebProfilerToolbar

See : 
![image](https://cloud.githubusercontent.com/assets/1071005/11680821/0a1ca292-9e5b-11e5-8c5c-f206cb1d57a6.png)
