### PR TITLE
Extend clients

### DIFF
--- a/src/CsaGuzzleBundle.php
+++ b/src/CsaGuzzleBundle.php
@@ -11,6 +11,7 @@
 
 namespace Csa\Bundle\GuzzleBundle;
 
+use Csa\Bundle\GuzzleBundle\DependencyInjection\CompilerPass\InheritancePass;
 use Csa\Bundle\GuzzleBundle\DependencyInjection\CompilerPass\LoaderPass;
 use Csa\Bundle\GuzzleBundle\DependencyInjection\CompilerPass\MiddlewarePass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -29,5 +30,6 @@ class CsaGuzzleBundle extends Bundle
 
         $container->addCompilerPass(new MiddlewarePass());
         $container->addCompilerPass(new LoaderPass());
+        $container->addCompilerPass(new InheritancePass());
     }
 }

--- a/src/DependencyInjection/CompilerPass/InheritancePass.php
+++ b/src/DependencyInjection/CompilerPass/InheritancePass.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * This file is part of the CsaGuzzleBundle package
+ *
+ * (c) Charles Sarrazin <charles@sarraz.in>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code
+ */
+
+namespace Csa\Bundle\GuzzleBundle\DependencyInjection\CompilerPass;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Csa Guzzle definition inheritancePass.
+ *
+ * @author Sofiane HADDAG <sofiane.haddag@yahoo.fr>
+ */
+class InheritancePass implements CompilerPassInterface
+{
+    const TAG = 'csa_guzzle.inheritance';
+
+    private $checkedNodes;
+
+    public function process(ContainerBuilder $container)
+    {
+        $ids = $container->findTaggedServiceIds(self::TAG);
+
+        if (!count($ids)) {
+            return;
+        }
+
+        $this->checkedNodes = [];
+
+        foreach ($ids as $id => $options) {
+            $client = $container->findDefinition($id);
+            $arguments = $client->getArguments();
+            $config = isset($arguments[0]) ? $arguments[0] : [];
+            $resolvedConfig = $this->resolveMerge($id, $client, $container, $config);
+
+            $client->replaceArgument(0, $resolvedConfig);
+        }
+    }
+
+    private function resolveMerge($id, $client, ContainerBuilder $container, array $config = [])
+    {
+        $tag = $client->getTag(self::TAG);
+        if (!isset($tag[0]['extends'])) {
+            throw new \RuntimeException(
+                sprintf('The tag "%s" require an attribute named "extends" of the service "%s".', self::TAG, $id)
+            );
+        }
+
+        $parent = $tag[0]['extends'];
+        $this->checkCircularReference($id, $parent);
+        $parentDefinition = $container->findDefinition($parent);
+        $parentArguments = $parentDefinition->getArguments();
+        $parentConfig = isset($parentArguments[0]) ? $parentArguments[0] : [];
+
+        $config = array_merge($parentConfig, $config);
+
+        if ($parentDefinition->hasTag(self::TAG)) {
+            $config = $this->resolveMerge($parent, $parentDefinition, $container, $config);
+        }
+
+        return $config;
+    }
+
+    private function checkCircularReference($id, $parent)
+    {
+        if (!isset($this->checkedNodes[$parent]) || !in_array($id, $this->checkedNodes[$parent])) {
+            $this->checkedNodes[$parent][] = $id;
+            if (isset($this->checkedNodes[$id])) {
+                if (in_array($parent, $this->checkedNodes[$id])) {
+                    throw new \RuntimeException(
+                        sprintf('Circular reference detected between services "%s" and "%s"', $parent, $id)
+                    );
+                }
+
+                $this->checkedNodes[$parent] = array_merge(
+                    $this->checkedNodes[$parent],
+                    $this->checkedNodes[$id]
+                );
+            }
+        }
+    }
+}

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -115,6 +115,7 @@ class Configuration implements ConfigurationInterface
                 ->children()
                     ->scalarNode('class')->defaultValue('GuzzleHttp\Client')->end()
                     ->booleanNode('lazy')->defaultFalse()->end()
+                    ->scalarNode('extends')->defaultNull()->end()
                     ->variableNode('config')->end()
                     ->arrayNode('middleware')
                         ->prototype('scalar')->end()

--- a/src/Resources/doc/clients.md
+++ b/src/Resources/doc/clients.md
@@ -49,6 +49,20 @@ csa_guzzle:
             # ...
 ```
 
+You can also ```extend``` another client.
+
+```yml
+csa_guzzle:
+    clients:
+        parent_one:
+            config: 
+                 headers: 
+                     Accept: application/json
+        my_client:
+            extends: parent_one
+            # ...
+```
+
 If you override your client's class, you can also set the class for your client:
 
 ```yml

--- a/src/Tests/DependencyInjection/CompilerPass/InheritancePassTest.php
+++ b/src/Tests/DependencyInjection/CompilerPass/InheritancePassTest.php
@@ -1,0 +1,212 @@
+<?php
+
+/*
+ * This file is part of the CsaGuzzleBundle package
+ *
+ * (c) Charles Sarrazin <charles@sarraz.in>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code
+ */
+
+namespace Csa\Bundle\GuzzleBundle\Tests\DependencyInjection\CompilerPass;
+
+use Csa\Bundle\GuzzleBundle\DependencyInjection\CompilerPass\InheritancePass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+class InheritancePassTest extends \PHPUnit_Framework_TestCase
+{
+    public function testClientWithoutConfigAndParentWithConfigWillMergeTheParentOne()
+    {
+        $container = $this->createContainer();
+        $parent = $this->createClient();
+        $parentConfig = ['proxy' => 'a'];
+        $parent->addArgument($parentConfig);
+        $container->setDefinition('parent.foo', $parent);
+
+        $client = $this->createClient('parent.foo');
+        $client->addArgument([]);
+        $container->setDefinition('client.bar', $client);
+
+        $pass = new InheritancePass();
+        $pass->process($container);
+
+        $clientDefinition = $container->findDefinition('client.bar');
+        $this->assertCount(1, $clientDefinition->getArguments(), 'Client inheritance error');
+        $this->assertEquals($parentConfig, $clientDefinition->getArgument(0), 'Client inheritance error');
+    }
+
+    public function testClientWithConfigAndParentWithConfigWillMergeBoth()
+    {
+        $container = $this->createContainer();
+        $parent = $this->createClient();
+        $parent->addArgument(['proxy' => 'a']);
+        $container->setDefinition('parent.foo', $parent);
+
+        $client = $this->createClient('parent.foo');
+        $client->addArgument(['verify' => false]);
+        $container->setDefinition('client.bar', $client);
+        $client->addTag(InheritancePass::TAG, ['extends' => 'parent.foo']);
+
+        $pass = new InheritancePass();
+        $pass->process($container);
+
+        $clientDefinition = $container->findDefinition('client.bar');
+        $this->assertEquals(
+            ['proxy' => 'a', 'verify' => false],
+            $clientDefinition->getArgument(0),
+            'Client inheritance error'
+        );
+    }
+
+    public function testClientWithoutConfigAndParentWithoutConfigWillResultNoConfig()
+    {
+        $container = $this->createContainer();
+        $parent = $this->createClient();
+        $parent->addArgument([]);
+        $container->setDefinition('parent.foo', $parent);
+
+        $client = $this->createClient('parent.foo');
+        $client->addArgument([]);
+        $container->setDefinition('client.bar', $client);
+
+        $pass = new InheritancePass();
+        $pass->process($container);
+
+        $clientDefinition = $container->findDefinition('client.bar');
+        $this->assertCount(0, $clientDefinition->getArgument(0), 'Client inheritance error');
+    }
+
+    public function testMultiplesRecursivesInheritances()
+    {
+        $container = $this->createContainer();
+
+        $clientA = $this->createClient();
+        $clientA->addArgument(['proxy' => 'a']);
+        $container->setDefinition('client.a', $clientA);
+
+        $clientB = $this->createClient('client.a');
+        $clientB->addArgument(['verify' => false]);
+        $container->setDefinition('client.b', $clientB);
+
+        $clientC = $this->createClient('client.b');
+        $clientC->addArgument(['verify' => true]);
+        $container->setDefinition('client.c', $clientC);
+
+        $clientD = $this->createClient('client.c');
+        $clientD->addArgument(['headers' => ['foo' => 'bar']]);
+        $container->setDefinition('client.d', $clientD);
+
+        $clientE = $this->createClient('client.b');
+        $clientE->addArgument(['headers' => ['foo' => 'baz']]);
+        $container->setDefinition('client.e', $clientE);
+
+        $pass = new InheritancePass();
+        $pass->process($container);
+
+        $aDefinition = $container->findDefinition('client.a');
+        $this->assertEquals(['proxy' => 'a'], $aDefinition->getArgument(0), 'Client inheritance error');
+
+        $bDefinition = $container->findDefinition('client.b');
+        $this->assertEquals(
+            ['proxy' => 'a', 'verify' => false],
+            $bDefinition->getArgument(0),
+            'Client inheritance error'
+        );
+
+        $cDefinition = $container->findDefinition('client.c');
+        $this->assertEquals(
+            ['proxy' => 'a', 'verify' => true],
+            $cDefinition->getArgument(0),
+            'Client inheritance error'
+        );
+
+        $dDefinition = $container->findDefinition('client.d');
+        $this->assertEquals(
+            ['proxy' => 'a', 'verify' => true, 'headers' => ['foo' => 'bar']],
+            $dDefinition->getArgument(0),
+            'Client inheritance error'
+        );
+
+        $eDefinition = $container->findDefinition('client.e');
+        $this->assertEquals(
+            ['proxy' => 'a', 'verify' => false, 'headers' => ['foo' => 'baz']],
+            $eDefinition->getArgument(0),
+            'Client inheritance error'
+        );
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     */
+    public function testCircularReference()
+    {
+        $container = $this->createContainer();
+
+        $clientA = $this->createClient('client.b');
+        $container->setDefinition('client.a', $clientA);
+
+        $clientB = $this->createClient('client.a');
+        $container->setDefinition('client.b', $clientB);
+
+        $pass = new InheritancePass();
+        $pass->process($container);
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     */
+    public function testCircularReferenceInDepth()
+    {
+        $container = $this->createContainer();
+
+        $clientA = $this->createClient('client.d');
+        $container->setDefinition('client.a', $clientA);
+
+        $clientB = $this->createClient('client.a');
+        $container->setDefinition('client.b', $clientB);
+
+        $clientC = $this->createClient('client.b');
+        $container->setDefinition('client.c', $clientC);
+
+        $clientD = $this->createClient('client.c');
+        $container->setDefinition('client.d', $clientD);
+
+        $pass = new InheritancePass();
+        $pass->process($container);
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage The tag "csa_guzzle.inheritance" require an attribute named "extends" of the service "client.a".
+     */
+    public function testTagWithoutExtendsWillThrowException()
+    {
+        $container = $this->createContainer();
+
+        $clientA = new Definition();
+        $clientA->addArgument([]);
+        $clientA->addTag(InheritancePass::TAG);
+        $container->setDefinition('client.a', $clientA);
+
+        $pass = new InheritancePass();
+        $pass->process($container);
+    }
+
+    private function createClient($parent = null)
+    {
+        $client = new Definition();
+
+        if ($parent) {
+            $client->addTag(InheritancePass::TAG, ['extends' => $parent]);
+        }
+
+        return $client;
+    }
+
+    private function createContainer()
+    {
+        return new ContainerBuilder();
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | no |
| License | MIT |
| Doc PR | Yes |

This PR make possible to override an existing Client configuration.

``` yml
csa_guzzle:
    clients:
        json:
            config:
                headers:
                    Accept: application/json
                    foo: foo
        symfony:
            class: GuzzleHttp\Client
            extends: json
            config:
                base_uri: https://symfony.com/
                # `symfony` Client config will extend `json`
```
