### PR TITLE
Hints for HttpClient configuration parameters

### DIFF
--- a/src/Resources/doc/clients.md
+++ b/src/Resources/doc/clients.md
@@ -15,8 +15,9 @@ Simply write the following code:
 csa_guzzle:
     clients:
         github_api:
-            config:
+            config: # you can specify the options as in http://docs.guzzlephp.org/en/latest/quickstart.html#creating-a-client
                 base_uri: https://api.github.com
+                timeout: 2.0
                 headers:
                     Accept: application/vnd.github.v3+json
 ```


### PR DESCRIPTION
Add timeout to sample configuration and add a hint that other parameters can be specified similarly to creating HttpClient manually.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT