### PR TITLE
fix the Composer cache directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ sudo: false
 cache:
   directories:
     - node_modules
-    - vendor
+    - $HOME/.composer/cache/files
     - bower_components
 
 webhooks:


### PR DESCRIPTION
Caching the `vendor` directory doesn't look like a good idea to me.
Instead I would cache the downloaded package archives.