### PR TITLE
Fix "No handler set" error from Guzzle's HandlerStack

### DIFF
--- a/src/DependencyInjection/CompilerPass/MiddlewarePass.php
+++ b/src/DependencyInjection/CompilerPass/MiddlewarePass.php
@@ -13,7 +13,7 @@ namespace Csa\Bundle\GuzzleBundle\DependencyInjection\CompilerPass;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\DefinitionDecorator;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
@@ -114,7 +114,7 @@ class MiddlewarePass implements CompilerPassInterface
             }
 
             if (!isset($options['handler'])) {
-                $handlerStack = new DefinitionDecorator('csa_guzzle.handler_stack');
+                $handlerStack = new Definition('csa_guzzle.handler_stack');
                 $handlerStack->setFactory(['GuzzleHttp\HandlerStack', 'create']);
                 $handlerStack->setPublic(false);
 

--- a/src/DependencyInjection/CompilerPass/MiddlewarePass.php
+++ b/src/DependencyInjection/CompilerPass/MiddlewarePass.php
@@ -115,7 +115,7 @@ class MiddlewarePass implements CompilerPassInterface
 
             if (!isset($options['handler'])) {
                 $handlerStack = new DefinitionDecorator('csa_guzzle.handler_stack');
-                $handlerStack->setClass('GuzzleHttp\HandlerStack');
+                $handlerStack->setFactory(['GuzzleHttp\HandlerStack', 'create']);
                 $handlerStack->setPublic(false);
 
                 $clientHandlerStackId = sprintf('csa_guzzle.handler_stack.%s', $clientId);

--- a/src/Resources/config/middleware.xml
+++ b/src/Resources/config/middleware.xml
@@ -6,10 +6,6 @@
 
     <services>
 
-        <service id="csa_guzzle.handler_stack" class="GuzzleHttp\HandlerStack" abstract="true">
-            <factory class="GuzzleHttp\HandlerStack" method="create" />
-        </service>
-
         <service id="csa_guzzle.middleware.stopwatch" class="Closure">
             <factory class="Csa\Bundle\GuzzleBundle\GuzzleHttp\Middleware" method="stopwatch" />
             <argument type="service" id="debug.stopwatch" />


### PR DESCRIPTION
The `setClass()` method from the decorator overrides the service definition (which uses a factory, not a class), and caused the compiler to instantiate the HandlerStack using the following code:

```php
$a = new HandlerStack();
```

instead of:

```php
$a = HandlerStack::create();
```

This caused the default handler stacks from Guzzle not to be added, and as a result it was raising an exception when trying to use the HTTP Client.

This was fixed by replacing `setClass()` with `setFactory()`, which doesn't override the parent service definition but also works around the null class name problem mentioned in d1a46db.

Involved versions:
 - Guzzle 6.1
 - Symfony 2.7