### PR TITLE
Added possibility to disable specific middleware.

### DIFF
--- a/src/Resources/doc/middleware.md
+++ b/src/Resources/doc/middleware.md
@@ -19,8 +19,7 @@ However, if you wish to, you can enable specific middleware, for a given client:
 
 ```yml
 csa_guzzle:
-    profiler: true
-    logger:   false
+    # ...
     clients:
         # Prototype
         github_api:
@@ -28,8 +27,21 @@ csa_guzzle:
                 base_uri: https://api.github.com
                 headers:
                     Accept: application/vnd.github.v3+json
-            middleware: [debug, my_middleware] # Note the use of the alias defined earlier in the service definition.
+            middleware: ['debug', 'my_middleware'] # Note the use of the alias defined earlier in the service definition.
 ```
+
+You can also disable specific middleware, by prefixing the middleware name with a `!` character:
+
+```yml
+csa_guzzle:
+    # ...
+    clients:
+        github_api:
+            # ...
+            middleware: ['!my_middleware']
+```
+
+Disabled middleware have priority over enabled middleware.
 
 When registering your own clients with the bundle, you can explicitly list all
 enabled middleware. The `middleware` attribute takes a space-delimited list of
@@ -38,7 +50,7 @@ for that client:
 
 ```xml
 <service id="acme.client" class="%acme.client.class%">
-    <tag name="csa_guzzle.client" middleware="my_middleware another_middleware" />
+    <tag name="csa_guzzle.client" middleware="my_middleware another_middleware !yet_another_middleware" />
 </service>
 ```
 

--- a/src/Tests/DependencyInjection/CompilerPass/MiddlewarePassTest.php
+++ b/src/Tests/DependencyInjection/CompilerPass/MiddlewarePassTest.php
@@ -54,6 +54,25 @@ class MiddlewarePassTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['push', [new Reference('bar'), 'bar']], $calls[1]);
     }
 
+    public function testDisableSpecificMiddlewareForClient()
+    {
+        $client = $this->createClient(['!foo', 'foo', 'bar']);
+
+        $container = $this->createContainer();
+        $container->setDefinition('client', $client);
+
+        foreach (['foo', 'bar', 'qux'] as $alias) {
+            $this->createMiddleware($container, $alias);
+        }
+
+        $pass = new MiddlewarePass();
+        $pass->process($container);
+
+        $handlerDefinition = $client->getArgument(0)['handler'];
+        $this->assertCount(1, $calls = $handlerDefinition->getMethodCalls());
+        $this->assertEquals(['push', [new Reference('bar'), 'bar']], $calls[0]);
+    }
+
     public function testMiddlewareWithPriority()
     {
         $client = $this->createClient();


### PR DESCRIPTION
Lets a user disable a specific middleware, by prefixing its name with a `!` character in the client config:

```yml
csa_guzzle:
    # ...
    clients:
        github_api:
            # ...
            middleware: ['!my_middleware']
```

Disabled middleware have priority over enabled middleware.