### PR TITLE
Fix #139 Allow to monitor multiple requests with the same uri

### DIFF
--- a/src/GuzzleHttp/Middleware.php
+++ b/src/GuzzleHttp/Middleware.php
@@ -29,15 +29,17 @@ class Middleware
     {
         return function (callable $handler) use ($stopwatch) {
             return function (RequestInterface $request, array $options) use ($handler, $stopwatch) {
-                $uri = (string) $request->getUri();
+                $key = (string) $request->getUri();
 
-                if (!$stopwatch->isStarted($uri)) {
-                    $stopwatch->start($uri);
+                // There is already a request watched this url
+                if ($stopwatch->isStarted($key)) {
+                    $key = $key.'[dupplicate]';
                 }
+                $stopwatch->start($key);
 
                 return $handler($request, $options)->then(
-                    function (ResponseInterface $response) use ($stopwatch, $uri) {
-                        $stopwatch->stop($uri);
+                    function (ResponseInterface $response) use ($stopwatch, $key) {
+                        $stopwatch->stop($key);
 
                         return $response;
                     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | [yes]
| New feature?  | [no]
| BC breaks?    | [no]
| Deprecations? | no]
| Tests pass?   | [yes]
| Fixed tickets | [https://github.com/csarrazi/CsaGuzzleBundle/issues/139]
| License       | MIT

This should fix watch on multiple concurrent requests with the same uri by adding a `[dupplicate]` tag at the end of the key.