### PR TITLE
Display info only if information is not null

### DIFF
--- a/src/Resources/views/Calls/list.html.twig
+++ b/src/Resources/views/Calls/list.html.twig
@@ -16,14 +16,16 @@
                 </span>
                 {% if call.cache is defined %}<span class="badge cache {{ call.cache|lower }}">Cache {{ call.cache }}</span>{% endif %}
                 {% if call.mock is defined %}<span class="badge mock {{ call.mock|lower }}">Mock {{ call.mock }}</span>{% endif %}
-                {% if call.info.total_time > 1 %}
-                    {% set duration_color = 'error' %}
-                {% elseif call.info.total_time < 0.2 %}
-                    {% set duration_color = 'success' %}
-                {% else %}
-                    {% set duration_color = 'warning' %}
+                {% if call.info %}
+                    {% if call.info.total_time > 1 %}
+                        {% set duration_color = 'error' %}
+                    {% elseif call.info.total_time < 0.2 %}
+                        {% set duration_color = 'success' %}
+                    {% else %}
+                        {% set duration_color = 'warning' %}
+                    {% endif %}
+                    <span class="badge duration {{ duration_color }}">{{ call.info.total_time|csa_guzzle_format_duration }}</span>
                 {% endif %}
-                <span class="badge duration {{ duration_color }}">{{ call.info.total_time|csa_guzzle_format_duration }}</span>
             </header>
 
             <div class="accordion-content{{ loop.first ? ' expanded': '' }}">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | [yes]
| New feature?  | [no]
| BC breaks?    | [no]
| Deprecations? | [no]
| Tests pass?   | [yes]
| License       | MIT

When you create another middleware of cache for exemple, time_info is not set and the Collector is break.