### PR TITLE
Changed Cache logic namespace

### DIFF
--- a/src/Cache/DoctrineAdapter.php
+++ b/src/Cache/DoctrineAdapter.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the CsaGuzzleBundle package
+ *
+ * (c) Charles Sarrazin <charles@sarraz.in>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code
+ */
+
+namespace Csa\Bundle\GuzzleBundle\Cache;
+
+use Csa\Bundle\GuzzleBundle\Cache\NamingStrategy\HashNamingStrategy;
+use Doctrine\Common\Cache\Cache;
+use GuzzleHttp\Psr7\Response;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class DoctrineAdapter implements StorageAdapterInterface
+{
+    private $cache;
+    private $namingStrategy;
+    private $ttl;
+
+    public function __construct(Cache $cache, $ttl = 0)
+    {
+        $this->cache = $cache;
+        $this->namingStrategy = new HashNamingStrategy();
+        $this->ttl = $ttl;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetch(RequestInterface $request)
+    {
+        $key = $this->namingStrategy->filename($request);
+
+        if ($this->cache->contains($key)) {
+            $data = $this->cache->fetch($key);
+
+            return new Response($data['status'], $data['headers'], $data['body'], $data['version'], $data['reason']);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function save(RequestInterface $request, ResponseInterface $response)
+    {
+        $data = [
+            'status' => $response->getStatusCode(),
+            'headers' => $response->getHeaders(),
+            'body' => (string) $response->getBody(),
+            'version' => $response->getProtocolVersion(),
+            'reason' => $response->getReasonPhrase(),
+        ];
+
+        $this->cache->save($this->namingStrategy->filename($request), $data, $this->ttl);
+
+        $response->getBody()->seek(0);
+    }
+}

--- a/src/Cache/MockStorageAdapter.php
+++ b/src/Cache/MockStorageAdapter.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of the CsaGuzzleBundle package
+ *
+ * (c) Charles Sarrazin <charles@sarraz.in>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code
+ */
+
+namespace Csa\Bundle\GuzzleBundle\Cache;
+
+use Csa\Bundle\GuzzleBundle\Cache\NamingStrategy\LegacyNamingStrategy;
+use Csa\Bundle\GuzzleBundle\Cache\NamingStrategy\NamingStrategyInterface;
+use Csa\Bundle\GuzzleBundle\Cache\NamingStrategy\SubfolderNamingStrategy;
+use GuzzleHttp\Psr7;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Filesystem\Filesystem;
+
+class MockStorageAdapter implements StorageAdapterInterface
+{
+    private $storagePath;
+    /** @var NamingStrategyInterface[] */
+    private $namingStrategies = [];
+    private $responseHeadersBlacklist = [
+        'X-Guzzle-Cache',
+    ];
+
+    /**
+     * @param string $storagePath
+     * @param array  $requestHeadersBlacklist
+     * @param array  $responseHeadersBlacklist
+     */
+    public function __construct($storagePath, array $requestHeadersBlacklist = [], array $responseHeadersBlacklist = [])
+    {
+        $this->storagePath = $storagePath;
+
+        $this->namingStrategies[] = new SubfolderNamingStrategy($requestHeadersBlacklist);
+        $this->namingStrategies[] = new LegacyNamingStrategy(true, $requestHeadersBlacklist);
+        $this->namingStrategies[] = new LegacyNamingStrategy(false, $requestHeadersBlacklist);
+
+        if (!empty($responseHeadersBlacklist)) {
+            $this->responseHeadersBlacklist  = $responseHeadersBlacklist;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetch(RequestInterface $request)
+    {
+        foreach ($this->namingStrategies as $strategy) {
+            if (file_exists($filename = $this->getFilename($strategy->filename($request)))) {
+                return Psr7\parse_response(file_get_contents($filename));
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function save(RequestInterface $request, ResponseInterface $response)
+    {
+        foreach ($this->responseHeadersBlacklist as $header) {
+            $response = $response->withoutHeader($header);
+        }
+
+        list($strategy) = $this->namingStrategies;
+
+        $filename = $this->getFilename($strategy->filename($request));
+
+        $fs = new Filesystem();
+        $fs->mkdir(dirname($filename));
+
+        file_put_contents($filename, Psr7\str($response));
+        $response->getBody()->rewind();
+    }
+
+    /**
+     * Prefixes the generated file path with the adapter's storage path.
+     *
+     * @param string $name
+     *
+     * @return string The path to the mock file
+     */
+    private function getFilename($name)
+    {
+        return $this->storagePath.'/'.$name.'.txt';
+    }
+}

--- a/src/Cache/NamingStrategy/AbstractNamingStrategy.php
+++ b/src/Cache/NamingStrategy/AbstractNamingStrategy.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code
  */
 
-namespace Csa\Bundle\GuzzleBundle\GuzzleHttp\Cache\NamingStrategy;
+namespace Csa\Bundle\GuzzleBundle\Cache\NamingStrategy;
 
 use Psr\Http\Message\RequestInterface;
 

--- a/src/Cache/NamingStrategy/HashNamingStrategy.php
+++ b/src/Cache/NamingStrategy/HashNamingStrategy.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code
  */
 
-namespace Csa\Bundle\GuzzleBundle\GuzzleHttp\Cache\NamingStrategy;
+namespace Csa\Bundle\GuzzleBundle\Cache\NamingStrategy;
 
 use Psr\Http\Message\RequestInterface;
 

--- a/src/Cache/NamingStrategy/LegacyNamingStrategy.php
+++ b/src/Cache/NamingStrategy/LegacyNamingStrategy.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code
  */
 
-namespace Csa\Bundle\GuzzleBundle\GuzzleHttp\Cache\NamingStrategy;
+namespace Csa\Bundle\GuzzleBundle\Cache\NamingStrategy;
 
 use Psr\Http\Message\RequestInterface;
 

--- a/src/Cache/NamingStrategy/NamingStrategyInterface.php
+++ b/src/Cache/NamingStrategy/NamingStrategyInterface.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code
  */
 
-namespace Csa\Bundle\GuzzleBundle\GuzzleHttp\Cache\NamingStrategy;
+namespace Csa\Bundle\GuzzleBundle\Cache\NamingStrategy;
 
 use Psr\Http\Message\RequestInterface;
 

--- a/src/Cache/NamingStrategy/SubfolderNamingStrategy.php
+++ b/src/Cache/NamingStrategy/SubfolderNamingStrategy.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code
  */
 
-namespace Csa\Bundle\GuzzleBundle\GuzzleHttp\Cache\NamingStrategy;
+namespace Csa\Bundle\GuzzleBundle\Cache\NamingStrategy;
 
 use Psr\Http\Message\RequestInterface;
 

--- a/src/Cache/StorageAdapterInterface.php
+++ b/src/Cache/StorageAdapterInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the CsaGuzzleBundle package
+ *
+ * (c) Charles Sarrazin <charles@sarraz.in>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code
+ */
+
+namespace Csa\Bundle\GuzzleBundle\Cache;
+
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+interface StorageAdapterInterface
+{
+    /**
+     * @param RequestInterface $request
+     *
+     * @return null|ResponseInterface
+     */
+    public function fetch(RequestInterface $request);
+
+    /**
+     * @param RequestInterface  $request
+     * @param ResponseInterface $response
+     */
+    public function save(RequestInterface $request, ResponseInterface $response);
+}

--- a/src/GuzzleHttp/Cache/DoctrineAdapter.php
+++ b/src/GuzzleHttp/Cache/DoctrineAdapter.php
@@ -11,54 +11,13 @@
 
 namespace Csa\Bundle\GuzzleBundle\GuzzleHttp\Cache;
 
-use Csa\Bundle\GuzzleBundle\GuzzleHttp\Cache\NamingStrategy\HashNamingStrategy;
-use Doctrine\Common\Cache\Cache;
-use GuzzleHttp\Psr7\Response;
-use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
+use Csa\Bundle\GuzzleBundle\Cache\DoctrineAdapter as BaseAdapter;
 
-class DoctrineAdapter implements StorageAdapterInterface
+/**
+ * Legacy doctrine adapter.
+ *
+ * @deprecated This class is deprecated since version 2.1. It will be removed in version 3.0.
+ */
+class DoctrineAdapter extends BaseAdapter implements StorageAdapterInterface
 {
-    private $cache;
-    private $namingStrategy;
-    private $ttl;
-
-    public function __construct(Cache $cache, $ttl = 0)
-    {
-        $this->cache = $cache;
-        $this->namingStrategy = new HashNamingStrategy();
-        $this->ttl = $ttl;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function fetch(RequestInterface $request)
-    {
-        $key = $this->namingStrategy->filename($request);
-
-        if ($this->cache->contains($key)) {
-            $data = $this->cache->fetch($key);
-
-            return new Response($data['status'], $data['headers'], $data['body'], $data['version'], $data['reason']);
-        }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function save(RequestInterface $request, ResponseInterface $response)
-    {
-        $data = [
-            'status' => $response->getStatusCode(),
-            'headers' => $response->getHeaders(),
-            'body' => (string) $response->getBody(),
-            'version' => $response->getProtocolVersion(),
-            'reason' => $response->getReasonPhrase(),
-        ];
-
-        $this->cache->save($this->namingStrategy->filename($request), $data, $this->ttl);
-
-        $response->getBody()->seek(0);
-    }
 }

--- a/src/GuzzleHttp/Cache/MockStorageAdapter.php
+++ b/src/GuzzleHttp/Cache/MockStorageAdapter.php
@@ -11,82 +11,13 @@
 
 namespace Csa\Bundle\GuzzleBundle\GuzzleHttp\Cache;
 
-use Csa\Bundle\GuzzleBundle\GuzzleHttp\Cache\NamingStrategy\LegacyNamingStrategy;
-use Csa\Bundle\GuzzleBundle\GuzzleHttp\Cache\NamingStrategy\NamingStrategyInterface;
-use Csa\Bundle\GuzzleBundle\GuzzleHttp\Cache\NamingStrategy\SubfolderNamingStrategy;
-use GuzzleHttp\Psr7;
-use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
-use Symfony\Component\Filesystem\Filesystem;
+use Csa\Bundle\GuzzleBundle\Cache\MockStorageAdapter as BaseAdapter;
 
-class MockStorageAdapter implements StorageAdapterInterface
+/**
+ * Legacy doctrine adapter.
+ *
+ * @deprecated This class is deprecated since version 2.1. It will be removed in version 3.0.
+ */
+class MockStorageAdapter extends BaseAdapter implements StorageAdapterInterface
 {
-    private $storagePath;
-    /** @var NamingStrategyInterface[] */
-    private $namingStrategies = [];
-    private $responseHeadersBlacklist = [
-        'X-Guzzle-Cache',
-    ];
-
-    /**
-     * @param string $storagePath
-     * @param array  $requestHeadersBlacklist
-     * @param array  $responseHeadersBlacklist
-     */
-    public function __construct($storagePath, array $requestHeadersBlacklist = [], array $responseHeadersBlacklist = [])
-    {
-        $this->storagePath = $storagePath;
-
-        $this->namingStrategies[] = new SubfolderNamingStrategy($requestHeadersBlacklist);
-        $this->namingStrategies[] = new LegacyNamingStrategy(true, $requestHeadersBlacklist);
-        $this->namingStrategies[] = new LegacyNamingStrategy(false, $requestHeadersBlacklist);
-
-        if (!empty($responseHeadersBlacklist)) {
-            $this->responseHeadersBlacklist  = $responseHeadersBlacklist;
-        }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function fetch(RequestInterface $request)
-    {
-        foreach ($this->namingStrategies as $strategy) {
-            if (file_exists($filename = $this->getFilename($strategy->filename($request)))) {
-                return Psr7\parse_response(file_get_contents($filename));
-            }
-        }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function save(RequestInterface $request, ResponseInterface $response)
-    {
-        foreach ($this->responseHeadersBlacklist as $header) {
-            $response = $response->withoutHeader($header);
-        }
-
-        list($strategy) = $this->namingStrategies;
-
-        $filename = $this->getFilename($strategy->filename($request));
-
-        $fs = new Filesystem();
-        $fs->mkdir(dirname($filename));
-
-        file_put_contents($filename, Psr7\str($response));
-        $response->getBody()->rewind();
-    }
-
-    /**
-     * Prefixes the generated file path with the adapter's storage path.
-     *
-     * @param string $name
-     *
-     * @return string The path to the mock file
-     */
-    private function getFilename($name)
-    {
-        return $this->storagePath.'/'.$name.'.txt';
-    }
 }

--- a/src/GuzzleHttp/Cache/StorageAdapterInterface.php
+++ b/src/GuzzleHttp/Cache/StorageAdapterInterface.php
@@ -11,21 +11,13 @@
 
 namespace Csa\Bundle\GuzzleBundle\GuzzleHttp\Cache;
 
-use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
+use Csa\Bundle\GuzzleBundle\Cache\StorageAdapterInterface as BaseAdapterInterface;
 
-interface StorageAdapterInterface
+/**
+ * Legacy doctrine adapter.
+ *
+ * @deprecated This interface is deprecated since version 2.1. It will be removed in version 3.0.
+ */
+interface StorageAdapterInterface extends BaseAdapterInterface
 {
-    /**
-     * @param RequestInterface $request
-     *
-     * @return null|ResponseInterface
-     */
-    public function fetch(RequestInterface $request);
-
-    /**
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
-     */
-    public function save(RequestInterface $request, ResponseInterface $response);
 }

--- a/src/GuzzleHttp/Middleware/CacheMiddleware.php
+++ b/src/GuzzleHttp/Middleware/CacheMiddleware.php
@@ -11,7 +11,7 @@
 
 namespace Csa\Bundle\GuzzleBundle\GuzzleHttp\Middleware;
 
-use Csa\Bundle\GuzzleBundle\GuzzleHttp\Cache\StorageAdapterInterface;
+use Csa\Bundle\GuzzleBundle\Cache\StorageAdapterInterface;
 use GuzzleHttp\Promise\FulfilledPromise;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;

--- a/src/GuzzleHttp/Middleware/MockMiddleware.php
+++ b/src/GuzzleHttp/Middleware/MockMiddleware.php
@@ -11,7 +11,7 @@
 
 namespace Csa\Bundle\GuzzleBundle\GuzzleHttp\Middleware;
 
-use Csa\Bundle\GuzzleBundle\GuzzleHttp\Cache\StorageAdapterInterface;
+use Csa\Bundle\GuzzleBundle\Cache\StorageAdapterInterface;
 use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Promise\RejectedPromise;
 use Psr\Http\Message\RequestInterface;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT

This PR moves the Cache logic outside from the GuzzleHttp namespace (except for the middleware).