### PR TITLE
Blacklist all Bundle headers, and use constants

### DIFF
--- a/src/Cache/MockStorageAdapter.php
+++ b/src/Cache/MockStorageAdapter.php
@@ -14,6 +14,8 @@ namespace Csa\Bundle\GuzzleBundle\Cache;
 use Csa\Bundle\GuzzleBundle\Cache\NamingStrategy\LegacyNamingStrategy;
 use Csa\Bundle\GuzzleBundle\Cache\NamingStrategy\NamingStrategyInterface;
 use Csa\Bundle\GuzzleBundle\Cache\NamingStrategy\SubfolderNamingStrategy;
+use Csa\Bundle\GuzzleBundle\GuzzleHttp\Middleware\CacheMiddleware;
+use Csa\Bundle\GuzzleBundle\GuzzleHttp\Middleware\MockMiddleware;
 use GuzzleHttp\Psr7;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -25,7 +27,8 @@ class MockStorageAdapter implements StorageAdapterInterface
     /** @var NamingStrategyInterface[] */
     private $namingStrategies = [];
     private $responseHeadersBlacklist = [
-        'X-Guzzle-Cache',
+        CacheMiddleware::DEBUG_HEADER,
+        MockMiddleware::DEBUG_HEADER,
     ];
 
     /**

--- a/src/Cache/NamingStrategy/AbstractNamingStrategy.php
+++ b/src/Cache/NamingStrategy/AbstractNamingStrategy.php
@@ -11,6 +11,8 @@
 
 namespace Csa\Bundle\GuzzleBundle\Cache\NamingStrategy;
 
+use Csa\Bundle\GuzzleBundle\GuzzleHttp\Middleware\CacheMiddleware;
+use Csa\Bundle\GuzzleBundle\GuzzleHttp\Middleware\HistoryMiddleware;
 use Psr\Http\Message\RequestInterface;
 
 abstract class AbstractNamingStrategy implements NamingStrategyInterface
@@ -18,7 +20,8 @@ abstract class AbstractNamingStrategy implements NamingStrategyInterface
     private $blacklist = [
         'User-Agent',
         'Host',
-        'X-Guzzle-Cache',
+        CacheMiddleware::DEBUG_HEADER,
+        HistoryMiddleware::CORRELATION_ID_HEADER,
     ];
 
     public function __construct(array $blacklist = [])

--- a/src/DataCollector/GuzzleCollector.php
+++ b/src/DataCollector/GuzzleCollector.php
@@ -11,7 +11,9 @@
 
 namespace Csa\Bundle\GuzzleBundle\DataCollector;
 
+use Csa\Bundle\GuzzleBundle\GuzzleHttp\Middleware\CacheMiddleware;
 use Csa\Bundle\GuzzleBundle\GuzzleHttp\Middleware\HistoryMiddleware;
+use Csa\Bundle\GuzzleBundle\GuzzleHttp\Middleware\MockMiddleware;
 use GuzzleHttp\TransferStats;
 use Namshi\Cuzzle\Formatter\CurlFormatter;
 use Psr\Http\Message\StreamInterface;
@@ -109,12 +111,12 @@ class GuzzleCollector extends DataCollector
 
                 $req['httpCode'] = $response->getStatusCode();
 
-                if ($response->hasHeader('X-Guzzle-Cache')) {
-                    $req['cache'] = $response->getHeaderLine('X-Guzzle-Cache');
+                if ($response->hasHeader(CacheMiddleware::DEBUG_HEADER)) {
+                    $req['cache'] = $response->getHeaderLine(CacheMiddleware::DEBUG_HEADER);
                 }
 
-                if ($response->hasHeader('X-Guzzle-Mock')) {
-                    $req['mock'] = $response->getHeaderLine('X-Guzzle-Mock');
+                if ($response->hasHeader(MockMiddleware::DEBUG_HEADER)) {
+                    $req['mock'] = $response->getHeaderLine(MockMiddleware::DEBUG_HEADER);
                 }
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | Apache License 2.0

#156 added a new header, but the cache naming strategies don't ignore it. Also spotted the `MockMiddleware` response header isn't ignored by default either.

Futhermore, I've switched the header names to use the constants (happy to revert if you'd rather).