### PR TITLE
Update GuzzleCollector.php

### DIFF
--- a/src/DataCollector/GuzzleCollector.php
+++ b/src/DataCollector/GuzzleCollector.php
@@ -13,6 +13,7 @@ namespace Csa\Bundle\GuzzleBundle\DataCollector;
 
 use Csa\Bundle\GuzzleBundle\GuzzleHttp\Middleware\HistoryMiddleware;
 use GuzzleHttp\TransferStats;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -104,7 +105,7 @@ class GuzzleCollector extends DataCollector
                 $req['curl'] = $this->curlFormatter->format($request);
             }
 
-            if ($response) {
+            if ($response instanceof ResponseInterface) {
                 $req['response'] = [
                     'reasonPhrase' => $response->getReasonPhrase(),
                     'headers' => $response->getHeaders(),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | Apache License 2.0


This fixes a common exception "Attempted to call an undefined method named "getReasonPhrase" of class "GuzzleHttp\Exception\ConnectException". in /var/www/vendor/csa/guzzle-bundle/src/DataCollector/GuzzleCollector.php on line 109" that happens in some situations on cURL timeouts.

In our current project, we are dealing with this issue for some time, and this simple type check fixes the issue.