### PR TITLE
Fix DataCollector on timeout

### DIFF
--- a/src/DataCollector/GuzzleCollector.php
+++ b/src/DataCollector/GuzzleCollector.php
@@ -11,10 +11,11 @@
 
 namespace Csa\Bundle\GuzzleBundle\DataCollector;
 
-use Csa\Bundle\GuzzleBundle\GuzzleHttp\History\History;
-use Csa\Bundle\GuzzleBundle\GuzzleHttp\Middleware\CacheMiddleware;
-use Csa\Bundle\GuzzleBundle\GuzzleHttp\Middleware\MockMiddleware;
-use GuzzleHttp\Exception\RequestException;
+use Csa\Bundle\GuzzleBundle\GuzzleHttp\Middleware\HistoryMiddleware;
+use GuzzleHttp\TransferStats;
+use Namshi\Cuzzle\Formatter\CurlFormatter;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -58,9 +59,9 @@ class GuzzleCollector extends DataCollector
         $data = [];
 
         foreach ($this->history as $request) {
-            /* @var \Psr\Http\Message\RequestInterface $request */
+            /* @var RequestInterface $request */
             $transaction = $this->history[$request];
-            /* @var \Psr\Http\Message\ResponseInterface $response */
+            /* @var ResponseInterface $response */
             $response = $transaction['response'];
             /* @var \Exception $error */
             $error = $transaction['error'];
@@ -84,7 +85,7 @@ class GuzzleCollector extends DataCollector
                 $req['curl'] = $this->curlFormatter->format($request);
             }
 
-            if ($response) {
+            if ($response instanceof ResponseInterface) {
                 $req['response'] = [
                     'reasonPhrase' => $response->getReasonPhrase(),
                     'headers' => $response->getHeaders(),


### PR DESCRIPTION
Sometimes, it appears that the `$response` variable is not an instanceof `ResponseInterface`
I propose this change (2 imports) and a better if statement (imho)

I also sorted the imports according to the PSR standard

| Q             | A
| ------------- | ---
| Bug fix?      | [yes]
| New feature?  | [no]
| BC breaks?    | [no]
| Deprecations? | [no]
| Tests pass?   | [yes]
| Fixed tickets | [comma separated list of tickets fixed by the PR]
| License       | Apache License 2.0

