### PR TITLE
Added list of all logs variable docs

### DIFF
--- a/src/Resources/doc/configuration_reference.md
+++ b/src/Resources/doc/configuration_reference.md
@@ -30,4 +30,37 @@ csa_guzzle:
         mode:                 replay
 ```
 
+To log request/response body you can use `{req_body}` and `{res_body}` respectively in `format` setting.
+
+Full list of logs variables with description:
+
+| Variable | 	Substitution |
+| --- | --- |
+| {request}	| Full HTTP request message | 
+| {response}	| Full HTTP response message | 
+| {ts}	 | Timestamp | 
+| {host} |	Host of the request | 
+| {method} |	Method of the request | 
+| {url}	 | URL of the request | 
+| {host} |	Host of the request | 
+| {protocol} | 	Request protocol | 
+| {version} | Protocol version | 
+| {resource}|	Resource of the request (path + query + fragment) | 
+| {port}	| Port of the request | 
+| {hostname} | 	Hostname of the machine that sent the request | 
+| {code} | Status code of the response (if available) | 
+| {phrase} | Reason phrase of the response (if available) | 
+| {curl_error} | Curl error message (if available) | 
+| {curl_code} | Curl error code (if available) | 
+| {curl_stderr} | Curl standard error (if available) | 
+| {connect_time} | Time in seconds it took to establish the connection (if available) | 
+| {total_time}	 | Total transaction time in seconds for last transfer (if available) | 
+| {req_header_*} | Replace * with the lowercased name of a request header to add to the message | 
+| {res_header_*} | Replace * with the lowercased name of a response header to add to the message | 
+| {req_body} | Request body  | 
+| {res_body} | Response body|
+
+
+Reference [Guzzle Log Plugin Docs](http://guzzle3.readthedocs.io/plugins/log-plugin.html#log-plugin)
+
 [Back to index](../../../README.md)


### PR DESCRIPTION
Listing all logs variables in one place will make it easy for developers to customise logs in yaml settings. I had to search for how to log request and response body so thought this will save someone time to do so :)

Thank you for your great bundle

| Q             | A
| ------------- | ---
| Bug fix?      | [yes|no]
| New feature?  | [yes|no]
| BC breaks?    | [yes|no]
| Deprecations? | [yes|no]
| Tests pass?   | [yes|no]
| Fixed tickets | [comma separated list of tickets fixed by the PR]
| License       | Apache License 2.0

