### PR TITLE
Use Twig namespace when referencing data-collector template

### DIFF
--- a/src/Resources/config/collector.xml
+++ b/src/Resources/config/collector.xml
@@ -11,7 +11,7 @@
         <service id="csa_guzzle.data_collector.guzzle" class="Csa\Bundle\GuzzleBundle\DataCollector\GuzzleCollector">
             <argument />
             <argument type="service" id="csa_guzzle.data_collector.history_bag" />
-            <tag name="data_collector" template="CsaGuzzleBundle:Collector:guzzle" id="guzzle" />
+            <tag name="data_collector" template="@CsaGuzzle/Collector/guzzle.html.twig" id="guzzle" />
         </service>
 
     </services>


### PR DESCRIPTION
I have an application that [uses Twig directly rather than the templating component](http://symfony.com/blog/new-in-symfony-2-7-twig-as-a-first-class-citizen). Currently CsaGuzzleBundle crashes the Profiler / DebugToolbar as it references a template using a syntax that is only supported in the templating bundle.

This allows the profiler to work when used in applications that disable
the templating component and instead use Twig directly.

The rest of the codebase already uses the `@namespace` style.

| Q             | A
| ------------- | ---
| Bug fix?      | [yes]
| New feature?  | [no]
| BC breaks?    | [no]
| Deprecations? | [no]
| Tests pass?   | [yes]
| Fixed tickets | [n/a]
| License       | Apache License 2.0

