### PR TITLE
Limit CurlFormatter usage for large requests

### DIFF
--- a/src/DataCollector/GuzzleCollector.php
+++ b/src/DataCollector/GuzzleCollector.php
@@ -80,7 +80,7 @@ class GuzzleCollector extends DataCollector
                 'error' => null,
             ];
 
-            if ($this->curlFormatter) {
+            if ($this->curlFormatter && $request->getBody()->getSize() <= $this->maxBodySize) {
                 $req['curl'] = $this->curlFormatter->format($request);
             }
 

--- a/tests/DataCollector/GuzzleCollectorTest.php
+++ b/tests/DataCollector/GuzzleCollectorTest.php
@@ -74,5 +74,10 @@ class GuzzleCollectorTest extends \PHPUnit_Framework_TestCase
             escapeshellarg('http://foo.bar')
         ), $calls[0]['curl']
         );
+
+        $client->post('http://foo.bar', ['body' => str_pad('', GuzzleCollector::MAX_BODY_SIZE + 1)]);
+        $collector->collect($request, $response, new \Exception());
+        $calls = $collector->getCalls();
+        $this->assertArrayNotHasKey('curl', $calls[1], 'This request body size shouldn\'t be passed to CurlFormatter');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #189
| License       | Apache License 2.0

