### PR TITLE
Added autoconfigure to configuration to tag client services automatically

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -75,6 +75,7 @@ class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
                 ->scalarNode('default_client')->info('The first client defined is used if not set')->end()
+                ->booleanNode('autoconfigure')->defaultFalse()->end()
                 ->append($this->createCacheNode())
                 ->append($this->createClientsNode())
                 ->append($this->createMockNode())

--- a/src/DependencyInjection/CsaGuzzleExtension.php
+++ b/src/DependencyInjection/CsaGuzzleExtension.php
@@ -54,7 +54,7 @@ class CsaGuzzleExtension extends Extension
             $container->removeDefinition('csa_guzzle.twig.extension');
         }
 
-        if ($config['autoconfigure']) {
+        if (method_exists($container, 'registerForAutoconfiguration') && $config['autoconfigure']) {
             $container->registerForAutoconfiguration(ClientInterface::class)
                 ->addTag('csa_guzzle.client');
         }

--- a/src/DependencyInjection/CsaGuzzleExtension.php
+++ b/src/DependencyInjection/CsaGuzzleExtension.php
@@ -54,6 +54,11 @@ class CsaGuzzleExtension extends Extension
             $container->removeDefinition('csa_guzzle.twig.extension');
         }
 
+        if ($config['autoconfigure']) {
+            $container->registerForAutoconfiguration(ClientInterface::class)
+                ->addTag('csa_guzzle.client');
+        }
+
         $this->processLoggerConfiguration($config['logger'], $container);
 
         $this->processMockConfiguration($config['mock'], $container, $loader, $config['profiler']['enabled']);

--- a/tests/AutoconfiguredClient.php
+++ b/tests/AutoconfiguredClient.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the CsaGuzzleBundle package
+ *
+ * (c) Charles Sarrazin <charles@sarraz.in>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code
+ */
+
+namespace Csa\Bundle\GuzzleBundle\Tests;
+
+use GuzzleHttp\ClientInterface;
+use Psr\Http\Message\RequestInterface;
+
+final class AutoconfiguredClient implements ClientInterface
+{
+    public function send(RequestInterface $request, array $options = [])
+    {
+    }
+
+    public function sendAsync(RequestInterface $request, array $options = [])
+    {
+    }
+
+    public function request($method, $uri, array $options = [])
+    {
+    }
+
+    public function requestAsync($method, $uri, array $options = [])
+    {
+    }
+
+    public function getConfig($option = null)
+    {
+    }
+}

--- a/tests/DependencyInjection/CsaGuzzleExtensionTest.php
+++ b/tests/DependencyInjection/CsaGuzzleExtensionTest.php
@@ -316,6 +316,11 @@ YAML;
         ];
 
         $container = $this->createContainer('', $services);
+
+        if (!method_exists($container, 'registerForAutoconfiguration')) {
+            $this->markTestSkipped('Not supported for this symfony version');
+        }
+
         $container->compile();
 
         $this->assertTrue($container->hasDefinition(AutoconfiguredClient::class));
@@ -334,6 +339,11 @@ autoconfigure: true
 YAML;
 
         $container = $this->createContainer($yaml, $services);
+
+        if (!method_exists($container, 'registerForAutoconfiguration')) {
+            $this->markTestSkipped('Not supported for this symfony version');
+        }
+
         $container->compile();
 
         $this->assertTrue($container->hasDefinition(AutoconfiguredClient::class));
@@ -348,7 +358,9 @@ YAML;
 
         foreach ($services as $serviceId => $serviceClass) {
             $definition = new Definition($serviceClass);
-            $definition->setAutoconfigured(true);
+            if (method_exists($definition, 'setAutoconfigured')) {
+                $definition->setAutoconfigured(true);
+            }
             $definition->setPublic(true);
 
             $container->setDefinition($serviceId, $definition);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #225
| License       | Apache License 2.0

I am not sure about fixturing services for tests (changes I made in `CsaGuzzleExtensionTest::createContainer`), if we prepare yaml instead I can change it.