### PR TITLE
Add doc about ability of deciding the level of logging

### DIFF
--- a/src/Resources/doc/available_middleware.md
+++ b/src/Resources/doc/available_middleware.md
@@ -76,6 +76,14 @@ csa_guzzle:
         format: debug
 ```
 
+You could also change the level of logging, for `dev`, you likely want `debug`, for `prod`, you likely want `error`. You'll find more log levels in the [LogLevel of php-fig](https://github.com/php-fig/log/blob/master/Psr/Log/LogLevel.php).
+
+```yml
+csa_guzzle:
+    logger:
+        enabled: true
+        level: debug
+```
 
 The `cache` middleware
 ----------------------


### PR DESCRIPTION
I want to figure out what levels are available during configuring this bundle for `prod`. 

After figuring out, I felt I spend too much time on it that I couldn't resist my urge to make the life of other newcomers to this bundle easier.

| Q             | A
| ------------- | ---
| Bug fix?      | [no]
| New feature?  | [no, unless you threat docs as code]
| BC breaks?    | [no]
| Deprecations? | [no]
| Tests pass?   | [Very likely yes]
| Fixed tickets | []
| License       | Apache License 2.0

