### PR TITLE
Fix: Remove cache-related service definitions when cache is disabled

### DIFF
--- a/src/DependencyInjection/CsaGuzzleExtension.php
+++ b/src/DependencyInjection/CsaGuzzleExtension.php
@@ -78,6 +78,7 @@ class CsaGuzzleExtension extends Extension
     private function processCacheConfiguration(array $config, ContainerBuilder $container)
     {
         if (!$config['enabled']) {
+            $container->removeDefinition('csa_guzzle.cache.adapter.doctrine');
             $container->removeDefinition('csa_guzzle.subscriber.cache');
 
             return;

--- a/src/Tests/DependencyInjection/CsaGuzzleExtensionTest.php
+++ b/src/Tests/DependencyInjection/CsaGuzzleExtensionTest.php
@@ -240,6 +240,64 @@ YAML;
         $this->assertSame('my.adapter.id', (string) $alias);
     }
 
+    /**
+     * @dataProvider providerCacheServices
+     *
+     * @param string $identifier
+     */
+    public function testServicesArePresentWhenCacheIsEnabled($identifier)
+    {
+        $yaml = <<<'YAML'
+cache:
+    enabled: true
+    adapter: foo
+YAML;
+
+        $container = $this->createContainer($yaml);
+
+        $this->assertTrue($container->hasDefinition($identifier), sprintf(
+            'Failed asserting that container has a definition for a service with identifier "%s".',
+            $identifier
+        ));
+    }
+
+    /**
+     * @dataProvider providerCacheServices
+     *
+     * @param string $identifier
+     */
+    public function testServicesAreAbsentWhenCacheIsDisabled($identifier)
+    {
+        $yaml = <<<'YAML'
+cache: 
+    enabled: false
+YAML;
+
+        $container = $this->createContainer($yaml);
+
+        $this->assertFalse($container->hasDefinition($identifier), sprintf(
+            'Failed asserting that container does not have a definition for a service with identifier "%s".',
+            $identifier
+        ));
+    }
+
+    /**
+     * @return array
+     */
+    public function providerCacheServices()
+    {
+        $identifiers = [
+            'csa_guzzle.cache.adapter.doctrine',
+            'csa_guzzle.subscriber.cache',
+        ];
+
+        return array_map(function ($identifier) {
+            return [
+                $identifier,
+            ];
+        }, $identifiers);
+    }
+
     public function testLegacyCacheConfiguration()
     {
         $yaml = <<<'YAML'


### PR DESCRIPTION
This PR

* [x] asserts that cache-related service definititions are removed from container when cache is disabled
* [x] removes cache-related service definititions from container when cache is disabled


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | maybe
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | Apache License 2.0
