### PR TITLE
Guzzle 7 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "csa/guzzle-cache-middleware": "^1.0.0",
         "csa/guzzle-history-middleware": "^1.0.0",
         "csa/guzzle-stopwatch-middleware": "^1.0.0",
-        "guzzlehttp/guzzle": "^6.1",
+        "guzzlehttp/guzzle": "^6.1 || ^7.0",
         "symfony/dependency-injection": "^2.8 || ^3.0 || ^4.0 || ^5.0",
         "symfony/filesystem": "^2.8 || ^3.0 || ^4.0 || ^5.0",
         "symfony/framework-bundle": "^2.8 || ^3.0 || ^4.0 || ^5.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | Apache License 2.0

Guzzle 7.0 is on its way (beta has been released already), and it's basically a non-breaking release that only removes some already deprecated things and bumps deps versions.
