### PR TITLE
Optionally prevent default_client

### DIFF
--- a/src/DependencyInjection/CsaGuzzleExtension.php
+++ b/src/DependencyInjection/CsaGuzzleExtension.php
@@ -129,7 +129,7 @@ class CsaGuzzleExtension extends Extension
 
     private function processClientsConfiguration(array $config, ContainerBuilder $container, $debug)
     {
-        if (empty($config['default_client'])) {
+        if (empty($config['default_client']) && false !== ($config['default_client'] ?? null)) {
             $keys = array_keys($config['clients']);
             $config['default_client'] = reset($keys);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | Apache License 2.0

The `default_client` option is used to autowire instances of a guzzle client. However, in a project that has multiple guzzle clients, this can lead to bugs as mentioned by @BPScott in https://github.com/csarrazi/CsaGuzzleBundle/pull/222#discussion_r158629335.

We recently ran into this very problem. We have a product that interacts with several third party APIs, and each of these APIs has a guzzle client. A new class was added that has a dependency on an explicit guzzle client, but the specific client to pass was accidentally not configured. This lead to an incorrect client being injected into the new class.

Conceptually, none of the guzzle clients we have should be considered the "default" one, as they're all "siblings" and do very different things. I understand that this configuration option was implemented similar to how Doctrine provides a default entity manager, but I'd argue Doctrine has a very different use-case to HTTP clients.

This pull request introduces the ability to disable the default client configuration. This pull request lets you set `default_client: false` in your configuration. As a result, if no guzzle client is explicitly  configured for an argument, an exception is thrown by the container. However, leaving this configuration option blank will behave as the library currently does - injecting the first guzzle client that is found.